### PR TITLE
[qtcontacts-sqlite] Explicitly finish queries in non-automatic storage

### DIFF
--- a/rpm/qtcontacts-sqlite.spec
+++ b/rpm/qtcontacts-sqlite.spec
@@ -1,5 +1,5 @@
 Name: qtcontacts-sqlite
-Version: 0.0.6
+Version: 0.0.7
 Release: 0
 Summary: SQLite-based plugin for QtContacts
 Group: System/Plugins

--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -104,7 +104,7 @@ private:
             QContactManager::Error *error);
 
     template <typename T> bool writeCommonDetails(
-                QContactLocalId contactId, const QSqlQuery &query, const T &detail, QContactManager::Error *error);
+                QContactLocalId contactId, const QVariant &detailId, const T &detail, QContactManager::Error *error);
     template <typename T> bool removeCommonDetails(
                 QContactLocalId contactId, QContactManager::Error *error);
 

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -464,6 +464,17 @@ void tst_QContactManager::dumpContactDifferences(const QContact& ca, const QCont
     }
 }
 
+static bool detailsEquivalent(const QContactDetail &lhs, const QContactDetail &rhs)
+{
+    // Same as operator== except ignores differences in accessConstraints values
+    if (lhs.definitionName() != rhs.definitionName())
+        return false;
+
+    QMap<QString, QVariant> lhsValues = lhs.variantValues();
+    QMap<QString, QVariant> rhsValues = rhs.variantValues();
+    return (lhsValues == rhsValues);
+}
+
 bool tst_QContactManager::isSuperset(const QContact& ca, const QContact& cb)
 {
     // returns true if contact ca is a superset of contact cb
@@ -481,7 +492,7 @@ bool tst_QContactManager::isSuperset(const QContact& ca, const QContact& cb)
     // First remove any matches
     foreach(QContactDetail d, aDetails) {
         foreach(QContactDetail d2, bDetails) {
-            if(d == d2) {
+            if (detailsEquivalent(d, d2)) {
                 a.removeDetail(&d);
                 b.removeDetail(&d2);
                 break;


### PR DESCRIPTION
Failure to finish queries leads to the SQLITE_LOCKED error.
