### PR TITLE
[qtcontacts-sqlite] Respond to relationship changes

### DIFF
--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -414,7 +414,7 @@ public:
     {
         if (!writer)
             writer = new ContactWriter(engine, database, reader);
-        m_error = writer->save(m_relationships, &m_errorMap);
+        m_error = writer->save(m_relationships, &m_errorMap, false);
     }
 
     void updateState(QContactAbstractRequest::State state)
@@ -447,7 +447,7 @@ public:
     {
         if (!writer)
             writer = new ContactWriter(engine, database, reader);
-        m_error = writer->remove(m_relationships, &m_errorMap);
+        m_error = writer->remove(m_relationships, &m_errorMap, false);
     }
 
     void updateState(QContactAbstractRequest::State state)
@@ -1059,7 +1059,7 @@ bool ContactsEngine::saveRelationships(
         m_synchronousWriter = new ContactWriter(*this, m_database, m_synchronousReader);
     }
 
-    QContactManager::Error err = m_synchronousWriter->save(*relationships, errorMap);
+    QContactManager::Error err = m_synchronousWriter->save(*relationships, errorMap, false);
     if (error)
         *error = err;
 
@@ -1100,7 +1100,7 @@ bool ContactsEngine::removeRelationships(
         m_synchronousWriter = new ContactWriter(*this, m_database, m_synchronousReader);
     }
 
-    QContactManager::Error err = m_synchronousWriter->remove(relationships, errorMap);
+    QContactManager::Error err = m_synchronousWriter->remove(relationships, errorMap, false);
     if (error)
         *error = err;
     return err == QContactManager::NoError;

--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -88,10 +88,12 @@ public:
 
     QContactManager::Error save(
             const QList<QContactRelationship> &relationships,
-            QMap<int, QContactManager::Error> *errorMap);
+            QMap<int, QContactManager::Error> *errorMap,
+            bool withinTransaction);
     QContactManager::Error remove(
             const QList<QContactRelationship> &relationships,
-            QMap<int, QContactManager::Error> *errorMap);
+            QMap<int, QContactManager::Error> *errorMap,
+            bool withinTransaction);
 
 private:
     bool beginTransaction();
@@ -102,9 +104,16 @@ private:
     QContactManager::Error update(QContact *contact, const DetailList &definitionMask, bool *aggregateUpdated, bool withinTransaction, bool withinAggregateUpdate);
     QContactManager::Error write(quint32 contactId, QContact *contact, const DetailList &definitionMask);
 
+    QContactManager::Error saveRelationships(const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap);
+    QContactManager::Error removeRelationships(const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap);
+
+#ifdef QTCONTACTS_SQLITE_PERFORM_AGGREGATION
     QContactManager::Error updateOrCreateAggregate(QContact *contact, const DetailList &definitionMask, bool withinTransaction);
     QContactManager::Error updateLocalAndAggregate(QContact *contact, const DetailList &definitionMask, bool withinTransaction);
     void regenerateAggregates(const QList<quint32> &aggregateIds, const DetailList &definitionMask, bool withinTransaction);
+    QContactManager::Error removeChildlessAggregates(QList<QContactIdType> *realRemoveIds);
+    QContactManager::Error aggregateOrphanedContacts(bool withinTransaction);
+#endif
 
     void bindContactDetails(const QContact &contact, QSqlQuery &query);
 
@@ -147,6 +156,7 @@ private:
     QSqlQuery m_findMatchForContact;
     QSqlQuery m_selectAggregateContactIds;
     QSqlQuery m_orphanAggregateIds;
+    QSqlQuery m_orphanContactIds;
     QSqlQuery m_checkContactExists;
     QSqlQuery m_existingContactIds;
     QSqlQuery m_selfContactId;

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -4280,7 +4280,11 @@ void tst_QContactManager::constituentOfSelf()
         QContactRelationship relationship;
         relationship = makeRelationship(QContactRelationship::Aggregates, aggregator.id(), constituent.id());
         QVERIFY(m.removeRelationship(relationship));
-        QVERIFY(m.removeContact(removalId(aggregator)));
+
+        // The aggregator should have been removed
+        QContact nonexistent = m.contact(retrievalId(aggregator));
+        QVERIFY(m.error() == QContactManager::DoesNotExistError);
+        QCOMPARE(nonexistent.id(), QContactId());
     }
 
     // Now connect our contact to the real self contact


### PR DESCRIPTION
If changes to relationships cause constituent contacts to become disaggregated, or aggregates to become childless, then remove or generate new aggregates as required to maintain order.
