### PR TITLE
[qtcontacts-sqlite] Fix linkage error

### DIFF
--- a/src/engine/conversion.cpp
+++ b/src/engine/conversion.cpp
@@ -158,7 +158,7 @@ int protocol(const QString &name)
     return propertyValue(name, protocols);
 }
 
-QString protocol(QContactOnlineAccount::Protocol type)
+QString protocol(int type)
 {
     static const QMap<int, QString> names(protocolNames());
 


### PR DESCRIPTION
The online account protocol conversion function was not found, due to
incorrect parameter specification.
