### PR TITLE
[qtcontacts-sqlite] Workaround invalid comparison of details

### DIFF
--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -1711,7 +1711,7 @@ QContactManager::Error ContactReader::queryContacts(
                 contact.saveDetail(&gender);
 
             QContactFavorite favorite;
-            setValue(&favorite, QContactFavorite::FieldFavorite, query.value(14));
+            setValue(&favorite, QContactFavorite::FieldFavorite, query.value(14).toBool());
             if (!favorite.isEmpty())
                 contact.saveDetail(&favorite);
 

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -66,7 +66,7 @@ static const char *createContactsTable =
         "\n created DATETIME,"
         "\n modified DATETIME,"
         "\n gender TEXT,"
-        "\n isFavorite INTEGER);";
+        "\n isFavorite BOOL);";
 
 static const char *createAddressesTable =
         "\n CREATE TABLE Addresses ("

--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -804,6 +804,10 @@ ContactsEngine::ContactsEngine(const QString &name)
     , m_synchronousWriter(0)
     , m_jobThread(0)
 {
+#ifdef USING_QTPIM
+    static bool registered = qRegisterMetaType<QList<int> >("QList<int>");
+    Q_UNUSED(registered)
+#endif
 }
 
 ContactsEngine::~ContactsEngine()

--- a/src/engine/contactsengine.h
+++ b/src/engine/contactsengine.h
@@ -44,7 +44,16 @@
 #include "contactwriter.h"
 #include "contactid_p.h"
 
+#ifdef USING_QTPIM
+// QList<int> is widely used in qtpim
+Q_DECLARE_METATYPE(QList<int>)
+#endif
+
 USE_CONTACTS_NAMESPACE
+
+// Force an ambiguity with QContactDetail::operator== so that we can't call it
+// It does not compare correctly if the values contains QList<int>
+inline void operator==(const QContactDetail &, const QContactDetail &) {}
 
 class JobThread;
 


### PR DESCRIPTION
Detail values of type QList<int> are not comparing correctly when compared in QVariant form.
