### PR TITLE
[qtcontacts-sqlite] Prefer the privileged database if accessible

### DIFF
--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -10,7 +10,8 @@ CONFIG += plugin
 PLUGIN_TYPE=contacts
 
 # we hardcode this for Qt4 as there's no GenericDataLocation offered by QDesktopServices
-DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"/home/nemo/.local/share/data/qtcontacts-sqlite/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DATABASE_DIR=\'\"/home/nemo/.privileged/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"/home/nemo/.local/share/data/\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_NAME=\'\"contacts.db\"\''
 
 HEADERS += \


### PR DESCRIPTION
If there is a privileged data store location, then attempt to create
or access the contacts database in that location.  If that location
is not accessible, fall back to the generic location.
