### PR TITLE
[qtcontacts-sqlite] Fix test failure

### DIFF
--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -1202,25 +1202,12 @@ static QString buildOrderBy(const QList<QContactSortOrder> &order, QString *join
     return fragments.join(QLatin1String(", "));
 }
 
-static void debugFilterExpansion(const QString &description, const QString &queryString, const QVariantList &bindings)
+static void debugFilterExpansion(const QString &description, const QString &query, const QVariantList &bindings)
 {
     static const bool debugFilters = !qgetenv("QTCONTACTS_SQLITE_DEBUG_FILTERS").isEmpty();
-    static const QChar marker = QChar::fromLatin1('?');
 
     if (debugFilters) {
-        QString query(queryString);
-
-        int index = 0;
-        for (int i = 0; i < bindings.count(); ++i) {
-            QString value = bindings.at(i).toString();
-            index = query.indexOf(marker, index);
-            if (index == -1)
-                break;
-
-            query.replace(index, 1, value);
-            index += value.length();
-        }
-        qDebug() << description << query;
+        qDebug() << description << ContactsDatabase::expandQuery(query, bindings);
     }
 }
 

--- a/src/engine/contactsdatabase.h
+++ b/src/engine/contactsdatabase.h
@@ -47,7 +47,9 @@ public:
     static QSqlDatabase open(const QString &databaseName);
     static QSqlQuery prepare(const char *statement, const QSqlDatabase &database);
 
-private:
+    static QString expandQuery(const QString &queryString, const QVariantList &bindings);
+    static QString expandQuery(const QString &queryString, const QMap<QString, QVariant> &bindings);
+    static QString expandQuery(const QSqlQuery &query);
 };
 
 BEGIN_CONTACTS_NAMESPACE

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -78,13 +78,13 @@ static const char *findMatchForContact =
         "\n   UNION"
         "\n   SELECT contactId, 3 as score FROM OnlineAccounts WHERE lowerAccountUri IN ( :uri )"
         "\n   UNION"
-        "\n   SELECT contactId, 3 as score FROM Contacts WHERE lowerFirstName != '' AND lowerFirstName = :first AND (lowerLastName == '' OR lowerLastName = :last)"
+        "\n   SELECT contactId, 3 as score FROM Contacts WHERE lowerFirstName != '' AND lowerFirstName = :firstName AND (lowerLastName = '' OR lowerLastName = :lastName)"
         "\n   UNION"
-        "\n   SELECT contactId, 2 as score FROM Contacts WHERE lowerFirstName != '' AND lowerFirstName LIKE :firstPartial AND (lowerLastName == '' OR lowerLastName = :last)"
+        "\n   SELECT contactId, 2 as score FROM Contacts WHERE lowerFirstName != '' AND lowerFirstName LIKE :firstPartial AND (lowerLastName = '' OR lowerLastName = :lastName)"
         "\n   UNION"
-        "\n   SELECT contactId, 2 as score FROM Contacts WHERE lowerFirstName = '' AND lowerLastName != '' AND lowerLastName = :last"
+        "\n   SELECT contactId, 2 as score FROM Contacts WHERE lowerFirstName = '' AND lowerLastName != '' AND lowerLastName = :lastName"
         "\n   UNION"
-        "\n   SELECT contactId, 1 as score FROM Nicknames WHERE lowerNickname != '' AND lowerNickname = :nick"
+        "\n   SELECT contactId, 1 as score FROM Nicknames WHERE lowerNickname != '' AND lowerNickname = :nickname"
         "\n ) AS Matches"
         "\n JOIN Contacts ON Contacts.contactId = Matches.contactId"
         "\n WHERE Contacts.syncTarget = 'aggregate'"
@@ -2374,10 +2374,10 @@ QContactManager::Error ContactWriter::updateOrCreateAggregate(QContact *contact,
     // or accumulating points for name matches (including partial matches of first name).
 
     m_findMatchForContact.bindValue(":id", contactId);
-    m_findMatchForContact.bindValue(":first", firstName);
+    m_findMatchForContact.bindValue(":firstName", firstName);
     m_findMatchForContact.bindValue(":firstPartial", firstName.prepend(Percent).append(Percent));
-    m_findMatchForContact.bindValue(":last", lastName);
-    m_findMatchForContact.bindValue(":nick", nickname);
+    m_findMatchForContact.bindValue(":lastName", lastName);
+    m_findMatchForContact.bindValue(":nickname", nickname);
     m_findMatchForContact.bindValue(":number", phoneNumbers.join(","));
     m_findMatchForContact.bindValue(":email", emailAddresses.join(","));
     m_findMatchForContact.bindValue(":uri", accountUris.join(","));


### PR DESCRIPTION
Signals wihtin transactions are coalesced by qtcontacts-sqlite, so
we should treat them as a set rather than as a list.

A qt4-specific error remains, where the query to match existing
aggeregates fails to find the correct candidate. It appears to be
failing due to the bound data item being corrupted in some way.
