### PR TITLE
[qtcontacts-sqlite] Improve aggregate search logic

### DIFF
--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -104,7 +104,7 @@ private:
     bool commitTransaction();
     void rollbackTransaction();
 
-    QContactManager::Error create(QContact *contact, const DetailList &definitionMask, bool withinTransaction, bool withinAggregateUpdate);
+    QContactManager::Error create(QContact *contact, const DetailList &definitionMask, int maxAggregateId, bool withinTransaction, bool withinAggregateUpdate);
     QContactManager::Error update(QContact *contact, const DetailList &definitionMask, bool *aggregateUpdated, bool withinTransaction, bool withinAggregateUpdate);
     QContactManager::Error write(quint32 contactId, QContact *contact, const DetailList &definitionMask);
 
@@ -112,7 +112,7 @@ private:
     QContactManager::Error removeRelationships(const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap);
 
 #ifdef QTCONTACTS_SQLITE_PERFORM_AGGREGATION
-    QContactManager::Error updateOrCreateAggregate(QContact *contact, const DetailList &definitionMask, bool withinTransaction);
+    QContactManager::Error updateOrCreateAggregate(QContact *contact, const DetailList &definitionMask, int maxAggregateId, bool withinTransaction);
     QContactManager::Error updateLocalAndAggregate(QContact *contact, const DetailList &definitionMask, bool withinTransaction);
     void regenerateAggregates(const QList<quint32> &aggregateIds, const DetailList &definitionMask, bool withinTransaction);
     QContactManager::Error removeChildlessAggregates(QList<QContactIdType> *realRemoveIds);
@@ -158,6 +158,7 @@ private:
     QSqlQuery m_findConstituentsForAggregate;
     QSqlQuery m_findLocalForAggregate;
     QSqlQuery m_findAggregateForContact;
+    QSqlQuery m_findMaximumContactId;
     QSqlQuery m_findMatchForContact;
     QSqlQuery m_selectAggregateContactIds;
     QSqlQuery m_childlessAggregateIds;


### PR DESCRIPTION
Determine maximum aggregate contact id prior to batch save, and avoid
attempting to aggregate multiple contacts from the same sync target.
This improves performance significantly as the database size grows.
