### PR TITLE
[qtcontacts-sqlite] Add status flag for online

### DIFF
--- a/rpm/qtcontacts-sqlite-qt5.spec
+++ b/rpm/qtcontacts-sqlite-qt5.spec
@@ -44,7 +44,7 @@ This package contains extension headers for the qtcontacts-sqlite-qt5 library.
 %files extensions
 %defattr(-,root,root,-)
 %{_libdir}/pkgconfig/qtcontacts-sqlite-qt5-extensions.pc
-%{_includedir}/qtcontacts-sqlite-extensions/*
+%{_includedir}/qtcontacts-sqlite-qt5-extensions/*
 
 
 %prep

--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -380,7 +380,7 @@ static void setValues(QContactPhoneNumber *detail, QSqlQuery *query, const int o
 
 static const FieldInfo presenceFields[] =
 {
-    { QContactPresence::FieldPresenceState, "presenceState", StringField },
+    { QContactPresence::FieldPresenceState, "presenceState", IntegerField },
     { QContactPresence::FieldTimestamp, "timestamp", DateField },
     { QContactPresence::FieldNickname, "nickname", StringField },
     { QContactPresence::FieldCustomMessage, "customMessage", StringField }
@@ -390,7 +390,7 @@ static void setValues(QContactPresence *detail, QSqlQuery *query, const int offs
 {
     typedef QContactPresence T;
 
-    setValue(detail, T::FieldPresenceState, query->value(offset + 0));
+    setValue(detail, T::FieldPresenceState, query->value(offset + 0).toInt());
     setValue(detail, T::FieldTimestamp    , query->value(offset + 1));
     setValue(detail, T::FieldNickname     , query->value(offset + 2));
     setValue(detail, T::FieldCustomMessage, query->value(offset + 3));
@@ -400,7 +400,7 @@ static void setValues(QContactGlobalPresence *detail, QSqlQuery *query, const in
 {
     typedef QContactPresence T;
 
-    setValue(detail, T::FieldPresenceState, query->value(offset + 0));
+    setValue(detail, T::FieldPresenceState, query->value(offset + 0).toInt());
     setValue(detail, T::FieldTimestamp    , query->value(offset + 1));
     setValue(detail, T::FieldNickname     , query->value(offset + 2));
     setValue(detail, T::FieldCustomMessage, query->value(offset + 3));
@@ -1719,6 +1719,7 @@ QContactManager::Error ContactReader::queryContacts(
             flags.setFlag(QContactStatusFlags::HasPhoneNumber, query.value(15).toBool());
             flags.setFlag(QContactStatusFlags::HasEmailAddress, query.value(16).toBool());
             flags.setFlag(QContactStatusFlags::HasOnlineAccount, query.value(17).toBool());
+            flags.setFlag(QContactStatusFlags::IsOnline, query.value(18).toBool());
             QContactManagerEngine::setDetailAccessConstraints(&flags, QContactDetail::ReadOnly | QContactDetail::Irremovable);
             contact.saveDetail(&flags);
 

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -67,7 +67,8 @@ static const char *createContactsTable =
         "\n isFavorite BOOL,"
         "\n hasPhoneNumber BOOL DEFAULT 0,"
         "\n hasEmailAddress BOOL DEFAULT 0,"
-        "\n hasOnlineAccount BOOL DEFAULT 0);";
+        "\n hasOnlineAccount BOOL DEFAULT 0,"
+        "\n isOnline BOOL DEFAULT 0);";
 
 static const char *createAddressesTable =
         "\n CREATE TABLE Addresses ("
@@ -559,11 +560,28 @@ static bool setContactsHasOnlineAccount(QSqlDatabase &database)
 
 static const ExtraColumn contactsHasOnlineAccount = { "Contacts", "hasOnlineAccount", "BOOL", &setContactsHasOnlineAccount };
 
+static bool setContactsIsOnline(QSqlDatabase &database)
+{
+    QString statement = QString::fromLatin1(
+        "UPDATE Contacts "
+        "SET isOnline = 1 "
+        "WHERE contactId in ("
+            "SELECT DISTINCT contactId "
+            "FROM GlobalPresences "
+            "WHERE presenceState >= 1 "
+            "AND presenceState <= 5);");
+
+    return execute(database, statement);
+}
+
+static const ExtraColumn contactsIsOnline = { "Contacts", "isOnline", "BOOL", &setContactsIsOnline };
+
 static const ExtraColumn *extraColumns[] =
 {
     &contactsHasPhoneNumber,
     &contactsHasEmailAddress,
-    &contactsHasOnlineAccount
+    &contactsHasOnlineAccount,
+    &contactsIsOnline
 };
 
 static bool addColumn(const ExtraColumn *columnDef, QSqlDatabase &database)

--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -42,14 +42,18 @@ SOURCES += \
 target.path = $$[QT_INSTALL_PLUGINS]/contacts
 INSTALLS += target
 
-headers.path = $${PREFIX}/include/qtcontacts-sqlite-extensions
+equals(QT_MAJOR_VERSION, 4): PACKAGENAME=qtcontacts-sqlite-extensions
+equals(QT_MAJOR_VERSION, 5): PACKAGENAME=qtcontacts-sqlite-qt5-extensions
+
+headers.path = $${PREFIX}/include/$${PACKAGENAME}
 headers.files = ../extensions/*
 headers.depends = ../extensions/*
 INSTALLS += headers
 
 pkgconfig.path = $${PREFIX}/lib/pkgconfig
-equals(QT_MAJOR_VERSION, 4): pkgconfig.files = ../qtcontacts-sqlite-extensions.pc
-equals(QT_MAJOR_VERSION, 5): pkgconfig.files = ../qtcontacts-sqlite-qt5-extensions.pc
+#equals(QT_MAJOR_VERSION, 4): pkgconfig.files = ../qtcontacts-sqlite-extensions.pc
+#equals(QT_MAJOR_VERSION, 5): pkgconfig.files = ../qtcontacts-sqlite-qt5-extensions.pc
+pkgconfig.files = ../$${PACKAGENAME}.pc
 INSTALLS += pkgconfig
 
 equals(QT_MAJOR_VERSION, 5): OTHER_FILES += plugin.json

--- a/src/extensions/qcontactstatusflags.h
+++ b/src/extensions/qcontactstatusflags.h
@@ -64,6 +64,7 @@ public:
         HasPhoneNumber = (1 << 0),
         HasEmailAddress = (1 << 1),
         HasOnlineAccount = (1 << 2),
+        IsOnline = (1 << 3),
     };
     Q_DECLARE_FLAGS(Flags, Flag)
 

--- a/src/qtcontacts-sqlite-extensions.pc
+++ b/src/qtcontacts-sqlite-extensions.pc
@@ -3,5 +3,5 @@ includedir=${prefix}/include/qtcontacts-sqlite-extensions
 
 Name: qtcontacts-sqlite-extensions
 Description: QtContacts extensions implemented by qtcontacts-sqlite
-Version: 0.1.1
+Version: 0.1.4
 Cflags:  -I${includedir}

--- a/src/qtcontacts-sqlite-qt5-extensions.pc
+++ b/src/qtcontacts-sqlite-qt5-extensions.pc
@@ -1,7 +1,7 @@
 prefix=/usr
-includedir=${prefix}/include/qtcontacts-sqlite-extensions
+includedir=${prefix}/include/qtcontacts-sqlite-qt5-extensions
 
 Name: qtcontacts-sqlite-qt5-extensions
 Description: QtContacts extensions implemented by qtcontacts-sqlite-qt5
-Version: 0.1.1
+Version: 0.1.4
 Cflags:  -I${includedir}


### PR DESCRIPTION
A contact is considered online if it has any presence state that is
not offline or unknown.

Also ensure that qtcontacts-sqlite-qt5 installs headers to a
different location to qtcontacts-sqlite.
