### PR TITLE
[qtcontacts-sqlite] Use centralised database location

### DIFF
--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -10,9 +10,11 @@ CONFIG += plugin hide_symbols
 PLUGIN_TYPE=contacts
 
 # we hardcode this for Qt4 as there's no GenericDataLocation offered by QDesktopServices
-DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DATABASE_DIR=\'\"/home/nemo/.privileged/\"\''
-DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"/home/nemo/.local/share/data/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_CENTRAL_DATA_DIR=\'\"/home/nemo/.local/share/system/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DIR=\'\"privileged\"\''
+DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite/\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_NAME=\'\"contacts.db\"\''
+# we build a path like: /home/nemo/.local/share/system/Contacts/qtcontacts-sqlite/contacts.db
 
 INCLUDEPATH += \
         ../extensions


### PR DESCRIPTION
Allows clearer separation between "system" data of different types,
as well as separate trees for privileged and unprivileged applications.
