### PR TITLE
[qtcontacts-sqlite] Improve support for changelog / timestamps

### DIFF
--- a/rpm/qtcontacts-sqlite-qt5.spec
+++ b/rpm/qtcontacts-sqlite-qt5.spec
@@ -1,5 +1,5 @@
 Name: qtcontacts-sqlite-qt5
-Version: 0.1.6
+Version: 0.1.9
 Release: 0
 Summary: SQLite-based plugin for QtPIM Contacts
 Group: System/Plugins

--- a/rpm/qtcontacts-sqlite.spec
+++ b/rpm/qtcontacts-sqlite.spec
@@ -1,5 +1,5 @@
 Name: qtcontacts-sqlite
-Version: 0.1.6
+Version: 0.1.9
 Release: 0
 Summary: SQLite-based plugin for QtContacts
 Group: System/Plugins

--- a/src/qtcontacts-sqlite-extensions.pc
+++ b/src/qtcontacts-sqlite-extensions.pc
@@ -3,5 +3,5 @@ includedir=${prefix}/include/qtcontacts-sqlite-extensions
 
 Name: qtcontacts-sqlite-extensions
 Description: QtContacts extensions implemented by qtcontacts-sqlite
-Version: 0.1.8
+Version: 0.1.9
 Cflags:  -I${includedir}

--- a/src/qtcontacts-sqlite-qt5-extensions.pc
+++ b/src/qtcontacts-sqlite-qt5-extensions.pc
@@ -3,5 +3,5 @@ includedir=${prefix}/include/qtcontacts-sqlite-qt5-extensions
 
 Name: qtcontacts-sqlite-qt5-extensions
 Description: QtContacts extensions implemented by qtcontacts-sqlite-qt5
-Version: 0.1.8
+Version: 0.1.9
 Cflags:  -I${includedir}

--- a/tests/auto/qcontactmanagerfiltering/tst_qcontactmanagerfiltering.cpp
+++ b/tests/auto/qcontactmanagerfiltering/tst_qcontactmanagerfiltering.cpp
@@ -725,6 +725,7 @@ void tst_QContactManagerFiltering::detailVariantFiltering_data()
          * Date times
          * A has QDateTime(QDate(2009, 06, 29), QTime(16, 52, 23, 0))
          * C has QDateTime(QDate(2009, 06, 29), QTime(16, 54, 17, 0))
+         * NOTE: value presence filtering can fail due to automatic timestamp insertion by qtcontacts-sqlite backend
          */
         const QDateTime adt(QDate(2009, 06, 29), QTime(16, 52, 23, 0));
         const QDateTime cdt(QDate(2009, 06, 29), QTime(16, 54, 17, 0));


### PR DESCRIPTION
This commit adds support for automatic timestamp generation.

If no creation timestamp exists at creation time, it will be
automatically generated (either the current datetime, or the
modification timestamp if that exists).

If no modification timestamp exists at modify time, it will be
automatically generated (as the current datetime).  Note that
if you want this timestamp to be consistently updated over time
across multiple saves, you need to _manually reset_ the value
between each save operation.  This is because it assumes that the
"true" modification timestamp might come from a sync source.
