### PR TITLE
[qtcontacts-sqlite] Use immediate locking mode for transactions

### DIFF
--- a/src/engine/contactsdatabase.h
+++ b/src/engine/contactsdatabase.h
@@ -45,6 +45,10 @@ public:
     static QSqlDatabase open(const QString &databaseName);
     static QSqlQuery prepare(const char *statement, const QSqlDatabase &database);
 
+    static bool beginTransaction(QSqlDatabase &database);
+    static bool commitTransaction(QSqlDatabase &database);
+    static bool rollbackTransaction(QSqlDatabase &database);
+
     static QString expandQuery(const QString &queryString, const QVariantList &bindings);
     static QString expandQuery(const QString &queryString, const QMap<QString, QVariant> &bindings);
     static QString expandQuery(const QSqlQuery &query);

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -571,7 +571,7 @@ bool ContactWriter::beginTransaction()
     // on write contention, and the backed-off process may never get access
     // if other processes are performing regular writes.
     if (m_databaseMutex->lock()) {
-        if (m_database.transaction())
+        if (ContactsDatabase::beginTransaction(m_database))
             return true;
 
         m_databaseMutex->unlock();
@@ -582,7 +582,7 @@ bool ContactWriter::beginTransaction()
 
 bool ContactWriter::commitTransaction()
 {
-    if (!m_database.commit()) {
+    if (!ContactsDatabase::commitTransaction(m_database)) {
         qWarning() << "Commit error:" << m_database.lastError();
         rollbackTransaction();
         return false;
@@ -611,7 +611,7 @@ bool ContactWriter::commitTransaction()
 
 void ContactWriter::rollbackTransaction()
 {
-    m_database.rollback();
+    ContactsDatabase::rollbackTransaction(m_database);
     if (m_databaseMutex->isLocked()) {
         m_databaseMutex->unlock();
     } else {


### PR DESCRIPTION
Since we already use exclusive locking via IPC, there will be no penalty
using immediate lock acquisition mode for transactions.  This appears to
fix the issue where readers spuriously report 'database disk image
is malformed' during writes by other processes.
