### PR TITLE
[qtcontacts-sqlite] Allow syncTarget details to be modifiable

### DIFF
--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -227,7 +227,8 @@ static const char *createDetailsTable =
         "\n linkedDetailUris TEXT,"
         "\n contexts TEXT,"
         "\n accessConstraints INTEGER,"
-        "\n provenance TEXT);";
+        "\n provenance TEXT,"
+        "\n modifiable BOOL);";
 
 static const char *createDetailsJoinIndex =
         "\n CREATE INDEX DetailsJoinIndex ON Details(detailId, detail);";
@@ -599,13 +600,16 @@ static const ExtraColumn contactsIsOnline = { "Contacts", "isOnline", "BOOL", &s
 
 static const ExtraColumn detailsProvenance = { "Details", "provenance", "TEXT", 0 };
 
+static const ExtraColumn detailsModifiable = { "Details", "modifiable", "BOOL", 0 };
+
 static const ExtraColumn *extraColumns[] =
 {
     &contactsHasPhoneNumber,
     &contactsHasEmailAddress,
     &contactsHasOnlineAccount,
     &contactsIsOnline,
-    &detailsProvenance
+    &detailsProvenance,
+    &detailsModifiable
 };
 
 static bool addColumn(const ExtraColumn *columnDef, QSqlDatabase &database)

--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -112,6 +112,8 @@ private:
     QContactManager::Error removeRelationships(const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap);
 
 #ifdef QTCONTACTS_SQLITE_PERFORM_AGGREGATION
+    QContactManager::Error calculateDelta(QContact *contact, const ContactWriter::DetailList &definitionMask,
+                                          QList<QContactDetail> *addDelta, QList<QContactDetail> *removeDelta, QList<QContact> *writeList);
     QContactManager::Error updateOrCreateAggregate(QContact *contact, const DetailList &definitionMask, int maxAggregateId, bool withinTransaction);
     QContactManager::Error updateLocalAndAggregate(QContact *contact, const DetailList &definitionMask, bool withinTransaction);
     void regenerateAggregates(const QList<quint32> &aggregateIds, const DetailList &definitionMask, bool withinTransaction);
@@ -165,6 +167,7 @@ private:
     QSqlQuery m_orphanContactIds;
     QSqlQuery m_checkContactExists;
     QSqlQuery m_existingContactIds;
+    QSqlQuery m_modifiableDetails;
     QSqlQuery m_selfContactId;
     QSqlQuery m_insertContact;
     QSqlQuery m_updateContact;

--- a/src/extensions/qtcontacts-extensions.h
+++ b/src/extensions/qtcontacts-extensions.h
@@ -55,8 +55,9 @@ QTM_BEGIN_NAMESPACE
 #endif
 
 #ifdef USING_QTPIM
-// In QContactDetail, we support the provenance property
+// In QContactDetail, we support the provenance and modifiable properties
 static const int QContactDetail__FieldProvenance = (QContactDetail::FieldLinkedDetailUris+1);
+static const int QContactDetail__FieldModifiable = (QContactDetail::FieldLinkedDetailUris+2);
 
 // In QContactDetail::contexts(), we support additional values, "Default" and "Large"
 static const int QContactDetail__ContextDefault = (QContactDetail::ContextOther+1);
@@ -88,6 +89,7 @@ static const QContactDetail::DetailType QContactDetail__TypeStatusFlags = static
 #else
 // Declared as static:
 Q_DECLARE_LATIN1_CONSTANT(QContactDetail__FieldProvenance, "Provenance") = { "Provenance" };
+Q_DECLARE_LATIN1_CONSTANT(QContactDetail__FieldModifiable, "Modifiable") = { "Modifiable" };
 
 Q_DECLARE_LATIN1_CONSTANT(QContactDetail__ContextDefault, "Default") = { "Default" };
 Q_DECLARE_LATIN1_CONSTANT(QContactDetail__ContextLarge, "Large") = { "Large" };


### PR DESCRIPTION
If a detail of a contact that has a syncTarget value other than 'local'
has the QContactDetail__FieldModifiable field set to true, then it
will be subject to modification during aggregate contact save.

If the aggregate has been modified such that a modifiable detail of
a syncTarget constituent has been removed, the save opertaion will
remove that detail from the original constituent.  Similarly, if the
aggregate has been updated to contain a modified detail and the
source detail is modifiable, the change will be applied to the source
detail.

If the relevant details are not marked as modifiable, the changes will
be applied to a local constituent.
