### PR TITLE
[qtcontacts-sqlite] Make modifiable property consistent

### DIFF
--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -128,10 +128,11 @@ private:
             QContact *contact,
             QSqlQuery &removeQuery,
             const DetailList &definitionMask,
+            bool syncable,
             QContactManager::Error *error);
 
     template <typename T> bool writeCommonDetails(
-                quint32 contactId, const QVariant &detailId, const T &detail, QContactManager::Error *error);
+                quint32 contactId, const QVariant &detailId, const T &detail, bool syncable, QContactManager::Error *error);
     template <typename T> bool removeCommonDetails(
                 quint32 contactId, QContactManager::Error *error);
 

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -952,10 +952,9 @@ void tst_Aggregation::updateAggregateOfLocalAndModifiableSync()
 
     const QContactName &localName(alice.detail<QContactName>());
 
+    // first syncTarget alice
+    QContact testAlice;
     {
-        // first syncTarget alice
-        QContact testAlice;
-
         QContactName name;
         name.setFirstName(localName.firstName());
         name.setMiddleName(localName.middleName());
@@ -988,10 +987,9 @@ void tst_Aggregation::updateAggregateOfLocalAndModifiableSync()
         QVERIFY(m_cm->saveContact(&testAlice));
     }
 
+    // second syncTarget alice
+    QContact trialAlice;
     {
-        // second syncTarget alice
-        QContact trialAlice;
-
         QContactName name;
         name.setFirstName(localName.firstName());
         name.setMiddleName(localName.middleName());
@@ -1072,6 +1070,32 @@ void tst_Aggregation::updateAggregateOfLocalAndModifiableSync()
     QCOMPARE(aggregateAlice.details<QContactOrganization>().size(), 1);
     QCOMPARE(detailProvenanceContact(aggregateAlice.detail<QContactOrganization>()), trialContact);
 
+    // Test the modifiability of the details
+
+    // Aggregate details are not modifiable
+    QCOMPARE(aggregateAlice.detail<QContactName>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.detail<QContactPhoneNumber>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.details<QContactEmailAddress>().at(0).value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.details<QContactEmailAddress>().at(1).value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.detail<QContactHobby>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.detail<QContactNote>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.detail<QContactOrganization>().value(QContactDetail__FieldModifiable).toBool(), false);
+
+    // The test contact should have some modifiable fields
+    testAlice = m_cm->contact(retrievalId(testAlice));
+    QCOMPARE(testAlice.detail<QContactName>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(testAlice.detail<QContactRingtone>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(testAlice.detail<QContactEmailAddress>().value(QContactDetail__FieldModifiable).toBool(), true);
+    QCOMPARE(testAlice.detail<QContactHobby>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(testAlice.detail<QContactNote>().value(QContactDetail__FieldModifiable).toBool(), true);
+
+    // The trial contact should also have some modifiable fields
+    trialAlice = m_cm->contact(retrievalId(trialAlice));
+    QCOMPARE(trialAlice.detail<QContactName>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(trialAlice.detail<QContactTag>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(trialAlice.detail<QContactEmailAddress>().value(QContactDetail__FieldModifiable).toBool(), true);
+    QCOMPARE(trialAlice.detail<QContactOrganization>().value(QContactDetail__FieldModifiable).toBool(), true);
+
     // now ensure that updates / modifies / removals work as expected
     {
         // locally-originated detail - should be modified
@@ -1143,6 +1167,28 @@ void tst_Aggregation::updateAggregateOfLocalAndModifiableSync()
     }
 
     QCOMPARE(aggregateAlice.details<QContactOrganization>().size(), 0);
+
+    // Modifiability should be unaffected
+
+    // Aggregate details are not modifiable
+    QCOMPARE(aggregateAlice.detail<QContactName>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.detail<QContactPhoneNumber>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.details<QContactEmailAddress>().at(0).value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.details<QContactEmailAddress>().at(1).value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(aggregateAlice.detail<QContactHobby>().value(QContactDetail__FieldModifiable).toBool(), false);
+
+    // The test contact should have some modifiable fields
+    testAlice = m_cm->contact(retrievalId(testAlice));
+    QCOMPARE(testAlice.detail<QContactName>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(testAlice.detail<QContactRingtone>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(testAlice.detail<QContactEmailAddress>().value(QContactDetail__FieldModifiable).toBool(), true);
+    QCOMPARE(testAlice.detail<QContactHobby>().value(QContactDetail__FieldModifiable).toBool(), false);
+
+    // The trial contact should also have some modifiable fields
+    trialAlice = m_cm->contact(retrievalId(trialAlice));
+    QCOMPARE(trialAlice.detail<QContactName>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(trialAlice.detail<QContactTag>().value(QContactDetail__FieldModifiable).toBool(), false);
+    QCOMPARE(trialAlice.detail<QContactEmailAddress>().value(QContactDetail__FieldModifiable).toBool(), true);
 }
 
 void tst_Aggregation::promotionToSingleLocal()

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -4319,11 +4319,11 @@ void tst_QContactManager::constituentOfSelf()
     QVERIFY(m.error() == QContactManager::NoError);
 
     constituent = m.contact(retrievalId(constituent));
-    QVERIFY(detailsEquivalent(constituent.detail<QContactNickname>(), nn));
+    QVERIFY(detailsSuperset(constituent.detail<QContactNickname>(), nn));
 
     // Change should be reflected in the self contact
     QContact self = m.contact(m.selfContactId());
-    QVERIFY(detailsEquivalent(self.detail<QContactNickname>(), nn));
+    QVERIFY(detailsSuperset(self.detail<QContactNickname>(), nn));
 
     // Check that no new aggregate has been generated
     foreach (const QContact &aggregator, m.contacts(relationshipFilter))
@@ -4343,12 +4343,11 @@ void tst_QContactManager::constituentOfSelf()
     QVERIFY(m.error() == QContactManager::NoError);
 
     constituent = m.contact(retrievalId(constituent));
-    QVERIFY(detailsEquivalent(constituent.detail<QContactPresence>(), presence));
+    QVERIFY(detailsSuperset(constituent.detail<QContactPresence>(), presence));
     QCOMPARE(constituent.detail<QContactGlobalPresence>().presenceState(), presence.presenceState());
 
     // Update should be relected in the self contact
     self = m.contact(m.selfContactId());
-    QVERIFY(detailsEquivalent(self.detail<QContactPresence>(), presence));
     QCOMPARE(self.detail<QContactGlobalPresence>().presenceState(), presence.presenceState());
 
     flags = self.detail<QContactStatusFlags>();
@@ -4363,11 +4362,10 @@ void tst_QContactManager::constituentOfSelf()
     QVERIFY(m.error() == QContactManager::NoError);
 
     constituent = m.contact(retrievalId(constituent));
-    QVERIFY(detailsEquivalent(constituent.detail<QContactPresence>(), presence));
+    QVERIFY(detailsSuperset(constituent.detail<QContactPresence>(), presence));
     QCOMPARE(constituent.detail<QContactGlobalPresence>().presenceState(), presence.presenceState());
 
     self = m.contact(m.selfContactId());
-    QVERIFY(detailsEquivalent(self.detail<QContactPresence>(), presence));
     QCOMPARE(self.detail<QContactGlobalPresence>().presenceState(), presence.presenceState());
 
     // Check that no new aggregate has been generated
@@ -4386,7 +4384,7 @@ void tst_QContactManager::constituentOfSelf()
     QVERIFY(m.error() == QContactManager::NoError);
 
     self = m.contact(m.selfContactId());
-    QVERIFY(detailsEquivalent(self.detail<QContactPresence>(), presence));
+    QCOMPARE(self.detail<QContactGlobalPresence>().presenceState(), presence.presenceState());
 
     flags = self.detail<QContactStatusFlags>();
     QCOMPARE(flags.testFlag(QContactStatusFlags::IsOnline), false);


### PR DESCRIPTION
The 'modifiable' property can only be set on the details of contacts which have a syncTarget not managed by the qtcontacts-sqlite backend itself.  Modifiability is preserved during promote-to-constituent operations, and is explicitly nullified for local and aggregate constituents.
