### PR TITLE
[qtcontacts-sqlite] Suppress debug output by default

### DIFF
--- a/rpm/qtcontacts-sqlite-qt5.spec
+++ b/rpm/qtcontacts-sqlite-qt5.spec
@@ -1,5 +1,5 @@
 Name: qtcontacts-sqlite-qt5
-Version: 0.1.9
+Version: 0.1.17
 Release: 0
 Summary: SQLite-based plugin for QtPIM Contacts
 Group: System/Plugins

--- a/src/engine/contactnotifier.cpp
+++ b/src/engine/contactnotifier.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "contactnotifier.h"
+#include "trace_p.h"
 
 #include <QDBusConnection>
 #include <QDBusMessage>
@@ -138,7 +139,7 @@ bool connect(const char *name, const char *signature, QObject *receiver, const c
     static QDBusConnection connection(QDBusConnection::sessionBus());
 
     if (!connection.isConnected()) {
-        qWarning() << "Session Bus is not connected";
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Session Bus is not connected"));
         return false;
     }
 
@@ -149,7 +150,7 @@ bool connect(const char *name, const char *signature, QObject *receiver, const c
                             QLatin1String(signature),
                             receiver,
                             slot)) {
-        qWarning() << "Unable to connect DBUS signal:" << name;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to connect DBUS signal: %1").arg(name));
         return false;
     }
 

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "contactsdatabase.h"
+#include "trace_p.h"
 
 #include <QDesktopServices>
 #include <QDir>
@@ -542,9 +543,9 @@ static bool execute(QSqlDatabase &database, const QString &statement)
 {
     QSqlQuery query(database);
     if (!query.exec(statement)) {
-        qWarning() << "Query failed";
-        qWarning() << query.lastError();
-        qWarning() << statement;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Query failed: %1\n%2")
+                .arg(query.lastError().text())
+                .arg(statement));
         return false;
     } else {
         return true;
@@ -650,7 +651,7 @@ static QStringList findExistingTables(QSqlDatabase &database)
 
     QSqlQuery query(database);
     if (!query.exec(sql)) {
-        qWarning() << "Unable to query tables";
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to query tables"));
     } else while (query.next()) {
         rv.append(query.value(0).toString());
     }
@@ -674,7 +675,7 @@ static QStringList findExistingColumns(const char *table, QSqlDatabase &database
 
     QSqlQuery query(database);
     if (!query.exec(statement)) {
-        qWarning() << "Unable to query columns for:" << table;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to query columns for: %1").arg(table));
     } else if (query.next()) {
         QString tableDef = query.value(0).toString();
 
@@ -713,11 +714,11 @@ static bool upgradeDatabase(QSqlDatabase &database)
         QStringList existingTables = findExistingTables(database);
         if (!existingTables.contains(table->name)) {
             if (!addTable(table, database)) {
-                qWarning() << "Unable to add table:" << table->name;
+                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to add table: %1").arg(table->name));
                 error = true;
             } else if (table->postInstall) {
                 if (!(*table->postInstall)(database)) {
-                    qWarning() << "Unable to run post install function for table:" << table->name;
+                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to run post install function for table: %1").arg(table->name));
                     error = true;
                 }
             }
@@ -725,7 +726,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
             if (error) {
                 break;
             } else {
-                qDebug() << "Added table:" << table->name;
+                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Added table: %1").arg(table->name));
             }
         }
     }
@@ -737,11 +738,11 @@ static bool upgradeDatabase(QSqlDatabase &database)
             QStringList existingColumns = findExistingColumns(column->table, database);
             if (!existingColumns.contains(column->name)) {
                 if (!addColumn(column, database)) {
-                    qWarning() << "Unable to add column:" << column->name << "to table:" << column->table;
+                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to add column: %1 to table: %2").arg(column->name).arg(column->table));
                     error = true;
                 } else if (column->postInstall) {
                     if (!(*column->postInstall)(database)) {
-                        qWarning() << "Unable to run post install function for column:" << column->name << "in table:" << column->table;
+                        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to run post install function for column: %1 in table: %2").arg(column->name).arg(column->table));
                         error = true;
                     }
                 }
@@ -749,7 +750,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
                 if (error) {
                     break;
                 } else {
-                    qDebug() << "Added column:" << column->name << "to table:" << column->table;
+                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Added column: %1 to table: %2").arg(column->name).arg(column->table));
                 }
             }
         }
@@ -769,8 +770,8 @@ static bool configureDatabase(QSqlDatabase &database)
         || !execute(database, QLatin1String(setupTempStore))
         || !execute(database, QLatin1String(setupJournal))
         || !execute(database, QLatin1String(setupSynchronous))) {
-        qWarning() << "Failed to configure contacts database";
-        qWarning() << database.lastError();
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to configure contacts database: %1")
+                .arg(database.lastError().text()));
         return false;
     }
 
@@ -791,9 +792,9 @@ static bool prepareDatabase(QSqlDatabase &database)
         QSqlQuery query(database);
 
         if (!query.exec(QLatin1String(createTables[i]))) {
-            qWarning() << "Table creation failed";
-            qWarning() << query.lastError();
-            qWarning() << createTables[i];
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Table creation failed: %1\n%2")
+                    .arg(query.lastError().text())
+                    .arg(createTables[i]));
             error = true;
             break;
         }
@@ -826,15 +827,15 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
     // Create the temporary table (if we haven't already).
     QSqlQuery tableQuery(db);
     if (!tableQuery.prepare(createStatement.arg(table))) {
-        qWarning() << "Failed to prepare temporary table query";
-        qWarning() << tableQuery.lastError();
-        qWarning() << createStatement;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare temporary table query: %1\n%2")
+                .arg(tableQuery.lastError().text())
+                .arg(createStatement));
         return false;
     }
     if (!tableQuery.exec()) {
-        qWarning() << "Failed to create temporary table";
-        qWarning() << tableQuery.lastError();
-        qWarning() << createStatement;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to create temporary table: %1\n%2")
+                .arg(tableQuery.lastError().text())
+                .arg(createStatement));
         return false;
     }
     tableQuery.finish();
@@ -842,15 +843,15 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
     // Delete all existing records.
     QSqlQuery deleteRecordsQuery(db);
     if (!deleteRecordsQuery.prepare(deleteRecordsStatement.arg(table))) {
-        qWarning() << "Failed to prepare delete records query";
-        qWarning() << deleteRecordsQuery.lastError();
-        qWarning() << deleteRecordsStatement;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare delete records query: %1\n%2")
+                .arg(deleteRecordsQuery.lastError().text())
+                .arg(deleteRecordsStatement));
         return false;
     }
     if (!deleteRecordsQuery.exec()) {
-        qWarning() << "Failed to delete temporary records";
-        qWarning() << deleteRecordsQuery.lastError();
-        qWarning() << deleteRecordsStatement;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to delete temporary records: %1\n%2")
+                .arg(deleteRecordsQuery.lastError().text())
+                .arg(deleteRecordsStatement));
         return false;
     }
     deleteRecordsQuery.finish();
@@ -862,18 +863,18 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
         // specified by filter
         const QString insertStatement = insertFilterStatement.arg(table).arg(join).arg(where).arg(orderBy);
         if (!insertQuery.prepare(insertStatement)) {
-            qWarning() << "Failed to prepare temporary contact ids";
-            qWarning() << insertQuery.lastError();
-            qWarning() << insertStatement;
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare temporary contact ids: %1\n%2")
+                    .arg(insertQuery.lastError().text())
+                    .arg(insertStatement));
             return false;
         }
         for (int i = 0; i < boundValues.count(); ++i) {
             insertQuery.bindValue(i, boundValues.at(i));
         }
         if (!insertQuery.exec()) {
-            qWarning() << "Failed to insert temporary contact ids";
-            qWarning() << insertQuery.lastError();
-            qWarning() << insertStatement;
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to insert temporary contact ids: %1\n%2")
+                    .arg(insertQuery.lastError().text())
+                    .arg(insertStatement));
             return false;
         } else {
             debugFilterExpansion("Contacts selection:", insertStatement, boundValues);
@@ -886,16 +887,16 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
         // order of input ids.
         const QString insertStatement = insertIdsStatement.arg(table);
         if (!insertQuery.prepare(insertStatement)) {
-            qWarning() << "Failed to prepare temporary contact ids";
-            qWarning() << insertQuery.lastError();
-            qWarning() << insertStatement;
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare temporary contact ids: %1\n%2")
+                    .arg(insertQuery.lastError().text())
+                    .arg(insertStatement));
             return false;
         }
         insertQuery.bindValue(0, boundIds);
         if (!insertQuery.execBatch()) {
-            qWarning() << "Failed to insert temporary contact ids";
-            qWarning() << insertQuery.lastError();
-            qWarning() << insertStatement;
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to insert temporary contact ids: %1\n%2")
+                    .arg(insertQuery.lastError().text())
+                    .arg(insertStatement));
             return false;
         }
     }
@@ -913,14 +914,14 @@ void clearTemporaryContactIdsTable(QSqlDatabase &db, const QString &table)
         QSqlQuery deleteRecordsQuery(db);
         const QString deleteRecordsStatement = QString::fromLatin1("DELETE FROM temp.%1").arg(table);
         if (!deleteRecordsQuery.prepare(deleteRecordsStatement)) {
-            qWarning() << "FATAL ERROR: Failed to prepare delete records query - the next query may return spurious results";
-            qWarning() << deleteRecordsQuery.lastError();
-            qWarning() << deleteRecordsStatement;
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("FATAL ERROR: Failed to prepare delete records query - the next query may return spurious results: %1\n%2")
+                    .arg(deleteRecordsQuery.lastError().text())
+                    .arg(deleteRecordsStatement));
         }
         if (!deleteRecordsQuery.exec()) {
-            qWarning() << "FATAL ERROR: Failed to delete temporary records - the next query may return spurious results";
-            qWarning() << deleteRecordsQuery.lastError();
-            qWarning() << deleteRecordsStatement;
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("FATAL ERROR: Failed to delete temporary records - the next query may return spurious results: %1\n%2")
+                    .arg(deleteRecordsQuery.lastError().text())
+                    .arg(deleteRecordsStatement));
         }
     }
 }
@@ -942,7 +943,7 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
     }
 
     if (!databaseDir.exists() && !databaseDir.mkpath(QString::fromLatin1("."))) {
-        qWarning() << "Unable to create contacts database directory:" << databaseDir.path();
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to create contacts database directory: %1").arg(databaseDir.path()));
         return QSqlDatabase();
     }
 
@@ -953,14 +954,14 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
     database.setDatabaseName(databaseFile);
 
     if (!database.open()) {
-        qWarning() << "Failed to open contacts database";
-        qWarning() << database.lastError();
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to open contacts database: %1")
+                .arg(database.lastError().text()));
         return database;
     }
 
     if (!exists && !prepareDatabase(database)) {
-        qWarning() << "Failed to prepare contacts database - removing";
-        qWarning() << database.lastError();
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare contacts database - removing: %1")
+                .arg(database.lastError().text()));
 
         database.close();
         QFile::remove(databaseFile);
@@ -968,8 +969,8 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
         return database;
     } else {
         if (!upgradeDatabase(database)) {
-            qWarning() << "Failed to upgrade contacts database";
-            qWarning() << database.lastError();
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to upgrade contacts database: %1")
+                    .arg(database.lastError().text()));
             return database;
         }
 
@@ -978,7 +979,7 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
         }
     }
 
-    qWarning() << "Opened contacts database:" << databaseFile;
+    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Opened contacts database: %1").arg(databaseFile));
     return database;
 }
 
@@ -1002,9 +1003,9 @@ QSqlQuery ContactsDatabase::prepare(const char *statement, const QSqlDatabase &d
     QSqlQuery query(database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        qWarning() << "Failed to prepare query";
-        qWarning() << query.lastError();
-        qWarning() << statement;
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare query: %1\n%2")
+                .arg(query.lastError().text())
+                .arg(statement));
         return QSqlQuery();
     }
     return query;

--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -35,6 +35,7 @@
 #include "contactnotifier.h"
 #include "contactreader.h"
 #include "contactwriter.h"
+#include "trace_p.h"
 
 #include "qtcontacts-extensions.h"
 #include "qtcontacts-extensions_impl.h"
@@ -610,7 +611,7 @@ public:
             for (;;) {
                 bool pendingJob = false;
                 if (m_currentJob && m_currentJob->request() == request) {
-                    qDebug() << "Wait for current job" << timeout;
+                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Wait for current job: %1 ms").arg(timeout));
                     // wait for the current job to updateState.
                     if (!m_finishedWait.wait(&m_mutex, timeout))
                         return false;
@@ -790,7 +791,8 @@ void JobThread::run()
             QElapsedTimer timer;
             timer.start();
             m_currentJob->execute(*m_engine, database, &reader, writer);
-            qDebug() << "Job executed in" << timer.elapsed() << ":" << m_currentJob->description() << ":" << m_currentJob->error();
+            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Job executed in %1 ms : %2 : error = %3")
+                    .arg(timer.elapsed()).arg(m_currentJob->description()).arg(m_currentJob->error()));
             locker.relock();
             m_finishedJobs.append(m_currentJob);
             m_currentJob = 0;
@@ -841,7 +843,7 @@ QContactManager::Error ContactsEngine::open()
         ContactNotifier::connect("relationshipsRemoved", "au", this, SLOT(_q_relationshipsRemoved(QVector<quint32>)));
         return QContactManager::NoError;
     } else {
-        qWarning() << "Unable to open database";
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to open database"));
         return QContactManager::UnspecifiedError;
     }
 }
@@ -1299,7 +1301,7 @@ void ContactsEngine::regenerateDisplayLabel(QContact &contact) const
     QContactManager::Error displayLabelError = QContactManager::NoError;
     QString label = synthesizedDisplayLabel(contact, &displayLabelError);
     if (displayLabelError != QContactManager::NoError) {
-        qWarning() << "Unable to regenerate displayLabel for contact:" << ContactId::toString(contact);
+        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to regenerate displayLabel for contact: %1").arg(ContactId::toString(contact)));
         return;
     }
 

--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -21,6 +21,7 @@ INCLUDEPATH += \
 
 HEADERS += \
         semaphore_p.h \
+        trace_p.h \
         conversion_p.h \
         contactid_p.h \
         contactsdatabase.h \

--- a/src/engine/semaphore_p.cpp
+++ b/src/engine/semaphore_p.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "semaphore_p.h"
+#include "trace_p.h"
 
 #include <errno.h>
 #include <unistd.h>
@@ -141,6 +142,6 @@ int Semaphore::value() const
 
 void Semaphore::error(const char *msg, int error)
 {
-    qWarning() << QString("%1 %2: %3 (%4)").arg(msg).arg(m_identifier).arg(::strerror(error)).arg(error);
+    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("%1 %2: %3 (%4)").arg(msg).arg(m_identifier).arg(::strerror(error)).arg(error));
 }
 

--- a/src/engine/trace_p.h
+++ b/src/engine/trace_p.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd.
+ * Contact: Matthew Vogt <matthew.vogt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef TRACE_P_H
+#define TRACE_P_H
+#include <QString>
+#include <QtDebug>
+
+static bool qtcontacts_sqlite_debug_trace_enabled()
+{
+    static const bool traceEnabled(!QString(QLatin1String(qgetenv("QTCONTACTS_SQLITE_TRACE"))).isEmpty());
+    return traceEnabled;
+}
+
+#define QTCONTACTS_SQLITE_DEBUG_TRACE(msg)                         \
+    do {                                                           \
+        if (Q_UNLIKELY(qtcontacts_sqlite_debug_trace_enabled())) { \
+            qWarning() << msg;                                     \
+        }                                                          \
+    } while (0)
+
+#endif


### PR DESCRIPTION
Previously, warnings and other debug output would be emitted by
default.  This commit changes the behavior so that the debugging
output is only emitted if the QTCONTACTS_SQLITE_TRACE env var is
set.
