### PR TITLE
[qtcontacts-sqlite] Always set ModifiedTimestamp on save.

### DIFF
--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -3080,25 +3080,15 @@ static bool updateTimestamp(QContact *contact, bool setCreationTimestamp)
 {
     QContactTimestamp timestamp = contact->detail<QContactTimestamp>();
     QDateTime createdTime = timestamp.created().toUTC();
-    QDateTime modifiedTime = timestamp.lastModified().toUTC();
-    bool needsSave = false;
+    QDateTime modifiedTime = QDateTime::currentDateTimeUtc();
 
-    if (!modifiedTime.isValid()) {
-        modifiedTime = QDateTime::currentDateTimeUtc();
-        timestamp.setLastModified(modifiedTime);
-        needsSave = true;
-    }
-
+    // always clobber last modified timestamp.
+    timestamp.setLastModified(modifiedTime);
     if (setCreationTimestamp && !createdTime.isValid()) {
         timestamp.setCreated(modifiedTime);
-        needsSave = true;
     }
 
-    if (needsSave) {
-        return contact->saveDetail(&timestamp);
-    }
-
-    return true;
+    return contact->saveDetail(&timestamp);
 }
 
 QContactManager::Error ContactWriter::create(QContact *contact, const DetailList &definitionMask, int maxAggregateId, bool withinTransaction, bool withinAggregateUpdate)


### PR DESCRIPTION
Previously, the modification timestamp was only set if it was empty.
This meant that clients could explicitly tell the backend to update
the timestamp, but setting it to empty prior to save; or they could
tell the backend not to update it, by setting an explicit timestamp
manually.

However, this meant that repeated (read, update, save) operations
would result in unintuitive behaviour: the backend would not update
the timestamp automatically unless the (update) step involved the
client manually _unsetting_ the modification timestamp.

This commit changes the behaviour so that the modification timestamp
is always updated to the current datetime during save.
