### PR TITLE
[qtcontacts-sqlite] Add automated test definitions

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,2 +1,6 @@
 TEMPLATE = subdirs
 SUBDIRS = auto benchmarks
+
+tests_xml.path = /opt/tests/qtcontacts-sqlite-qt5/
+tests_xml.files = tests.xml
+equals(QT_MAJOR_VERSION, 5): INSTALLS += tests_xml

--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testdefinition version="1.0">
+   <suite name="qtcontacts-sqlite-qt5-tests" domain="mw">
+       <description>QtContacts SQLite backend automatic tests</description>
+       <set name="unit-tests" feature="qtcontacts-sqlite-qt5">
+           <description>Backend correctness automatic tests</description>
+           <case manual="false" name="aggregation">
+               <step>/opt/tests/qtcontacts-sqlite-qt5/tst_aggregation</step>
+           </case>
+           <case manual="false" name="contactmanager">
+               <step>/opt/tests/qtcontacts-sqlite-qt5/tst_qcontactmanager</step>
+           </case>
+       </set>
+   </suite>
+</testdefinition>


### PR DESCRIPTION
We should run the tst_aggregation and tst_qcontactmanager to verify
correctness of each build.  Note that the fetchtimes benchmark is
not part of the test definition, as it doesn't test correctness.

We only do this for Qt5 builds.
