### PR TITLE
[qtcontacts-sqlite] Emit warnings without configuration

### DIFF
--- a/src/engine/contactnotifier.cpp
+++ b/src/engine/contactnotifier.cpp
@@ -139,7 +139,7 @@ bool connect(const char *name, const char *signature, QObject *receiver, const c
     static QDBusConnection connection(QDBusConnection::sessionBus());
 
     if (!connection.isConnected()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Session Bus is not connected"));
+        QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Session Bus is not connected"));
         return false;
     }
 
@@ -150,7 +150,7 @@ bool connect(const char *name, const char *signature, QObject *receiver, const c
                             QLatin1String(signature),
                             receiver,
                             slot)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to connect DBUS signal: %1").arg(name));
+        QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Unable to connect DBUS signal: %1").arg(name));
         return false;
     }
 

--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -823,7 +823,7 @@ static QString buildWhere(const QContactDetailFilter &filter, QVariantList *bind
 {
     if (filter.matchFlags() & QContactFilter::MatchKeypadCollation) {
         *failed = true;
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with filter requiring keypad collation"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with filter requiring keypad collation"));
         return QLatin1String("FAILED");
     }
 
@@ -871,7 +871,7 @@ static QString buildWhere(const QContactDetailFilter &filter, QVariantList *bind
                             }
                         }
                     } else {
-                        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unsupported flags matching contact status flags"));
+                        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unsupported flags matching contact status flags"));
                         continue;
                     }
 
@@ -995,9 +995,9 @@ static QString buildWhere(const QContactDetailFilter &filter, QVariantList *bind
 
     *failed = true;
 #ifdef USING_QTPIM
-    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with unknown DetailFilter detail: %1").arg(filter.detailType()));
+    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown DetailFilter detail: %1").arg(filter.detailType()));
 #else
-    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with unknown DetailFilter detail: %1").arg(filter.detailDefinitionName()));
+    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown DetailFilter detail: %1").arg(filter.detailDefinitionName()));
 #endif
     return QLatin1String("FALSE");
 }
@@ -1082,9 +1082,9 @@ static QString buildWhere(const QContactDetailRangeFilter &filter, QVariantList 
 
     *failed = true;
 #ifdef USING_QTPIM
-    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with unknown DetailRangeFilter detail: %1").arg(filter.detailType()));
+    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown DetailRangeFilter detail: %1").arg(filter.detailType()));
 #else
-    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with unknown DetailRangeFilter detail: %1").arg(filter.detailDefinitionName()));
+    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown DetailRangeFilter detail: %1").arg(filter.detailDefinitionName()));
 #endif
     return QLatin1String("FALSE");
 }
@@ -1102,7 +1102,7 @@ static QString buildWhere(const QContactLocalIdFilter &filter, QVariantList *bin
 
     if (dbIds.isEmpty()) {
         *failed = true;
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with empty contact ID list"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with empty contact ID list"));
         return QLatin1String("FALSE");
     }
 
@@ -1135,7 +1135,7 @@ static QString buildWhere(const QContactRelationshipFilter &filter, QVariantList
     if (!rci.managerUri().isEmpty() && rci.managerUri() != QLatin1String("org.nemomobile.contacts.sqlite")) {
 #endif
         *failed = true;
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with invalid manager URI: %1").arg(rci.managerUri()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with invalid manager URI: %1").arg(rci.managerUri()));
         return QLatin1String("FALSE");
     }
 
@@ -1212,7 +1212,7 @@ static QString buildWhere(const QContactChangeLogFilter &filter, QVariantList *b
     }
 
     *failed = true;
-    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with changelog filter on removed timestamps"));
+    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with changelog filter on removed timestamps"));
     return QLatin1String("FALSE");
 }
 
@@ -1279,7 +1279,7 @@ static QString buildWhere(const QContactFilter &filter, QVariantList *bindings, 
 #endif
     default:
         *failed = true;
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot buildWhere with unknown filter type: %1").arg(filter.type()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot buildWhere with unknown filter type: %1").arg(filter.type()));
         return QLatin1String("FALSE");
     }
 }
@@ -1332,7 +1332,7 @@ static QString buildOrderBy(const QContactSortOrder &order, QStringList *joins)
                         .arg(QLatin1String(field.column))
                         .arg(collate).arg(direction);
             } else {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("UNSUPPORTED SORTING: no join and not primary table for ORDER BY in query with: %1, %2")
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("UNSUPPORTED SORTING: no join and not primary table for ORDER BY in query with: %1, %2")
 #ifdef USING_QTPIM
                            .arg(order.detailType()).arg(order.detailField()));
 #else
@@ -1443,7 +1443,7 @@ bool includesSelfId(const QContactFilter &filter)
 #endif
 
     default:
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot includesSelfId with unknown filter type %1").arg(filter.type()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot includesSelfId with unknown filter type %1").arg(filter.type()));
         return false;
     }
 }
@@ -1501,7 +1501,7 @@ QContactManager::Error ContactReader::readContacts(
     QVariantList bindings;
     QString where = buildWhere(filter, &bindings, &whereFailed);
     if (whereFailed) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -1568,7 +1568,7 @@ QContactManager::Error ContactReader::queryContacts(
             "\n SELECT Contacts.*"
             "\n FROM temp.%1 INNER JOIN Contacts ON temp.%1.contactId = Contacts.contactId"
             "\n ORDER BY temp.%1.rowId ASC;")).arg(tableName))) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to query from %1: %2").arg(tableName).arg(query.lastError().text()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query from %1: %2").arg(tableName).arg(query.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
 
@@ -1613,7 +1613,7 @@ QContactManager::Error ContactReader::queryContacts(
                 const QString tableQueryStatement(tableTemplate.arg(QLatin1String(detail.table)));
                 table.query.setForwardOnly(true);
                 if (!table.query.prepare(tableQueryStatement)) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare table %1:\n%2\n%3")
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare table %1:\n%2\n%3")
                             .arg(detail.table)
                             .arg(tableQueryStatement)
                             .arg(table.query.lastError().text()));
@@ -1630,7 +1630,7 @@ QContactManager::Error ContactReader::queryContacts(
                 table.query.bindValue(0, detail.detail);
 #endif
                 if (!table.query.exec()) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to query table %1:\n%2")
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query table %1:\n%2")
                             .arg(detail.table)
                             .arg(table.query.lastError().text()));
                 } else if (table.query.next()) {
@@ -1665,12 +1665,12 @@ QContactManager::Error ContactReader::queryContacts(
 
         table.query.setForwardOnly(true);
         if (!table.query.prepare(relationshipQuery)) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare relationship table query:\n%1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare relationship table query:\n%1\n%2")
                     .arg(relationshipQuery)
                     .arg(table.query.lastError().text()));
         } else {
             if (!table.query.exec()) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to query relationship table: %1")
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query relationship table: %1")
                         .arg(table.query.lastError().text()));
             } else if (table.query.next()) {
                 table.currentId = table.query.value(0).toUInt();
@@ -1808,7 +1808,7 @@ QContactManager::Error ContactReader::readContactIds(
     QString where = buildWhere(filter, &bindings, &failed);
 
     if (failed) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create WHERE expression: invalid filter specification"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -1823,7 +1823,7 @@ QContactManager::Error ContactReader::readContactIds(
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(queryString)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare contacts ids:\n%1\nQuery:\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare contacts ids:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
                 .arg(queryString));
         return QContactManager::UnspecifiedError;
@@ -1833,7 +1833,7 @@ QContactManager::Error ContactReader::readContactIds(
         query.bindValue(i, bindings.at(i));
 
     if (!query.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare contacts ids\n%1\nQuery:\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query contacts ids\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
                 .arg(queryString));
         return QContactManager::UnspecifiedError;
@@ -1913,7 +1913,7 @@ QContactManager::Error ContactReader::readRelationships(
     QSqlQuery query(m_database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare relationships query:\n%1\nQuery:\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare relationships query:\n%1\nQuery:\n%2")
                 .arg(query.lastError().text())
                 .arg(statement));
         return QContactManager::UnspecifiedError;
@@ -1923,7 +1923,7 @@ QContactManager::Error ContactReader::readRelationships(
         query.bindValue(i, bindings.at(i));
 
     if (!query.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to query relationships: %1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to query relationships: %1")
                 .arg(query.lastError().text()));
         return QContactManager::UnspecifiedError;
     }

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -543,7 +543,7 @@ static bool execute(QSqlDatabase &database, const QString &statement)
 {
     QSqlQuery query(database);
     if (!query.exec(statement)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Query failed: %1\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Query failed: %1\n%2")
                 .arg(query.lastError().text())
                 .arg(statement));
         return false;
@@ -651,7 +651,7 @@ static QStringList findExistingTables(QSqlDatabase &database)
 
     QSqlQuery query(database);
     if (!query.exec(sql)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to query tables"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to query tables"));
     } else while (query.next()) {
         rv.append(query.value(0).toString());
     }
@@ -675,7 +675,7 @@ static QStringList findExistingColumns(const char *table, QSqlDatabase &database
 
     QSqlQuery query(database);
     if (!query.exec(statement)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to query columns for: %1").arg(table));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to query columns for: %1").arg(table));
     } else if (query.next()) {
         QString tableDef = query.value(0).toString();
 
@@ -714,11 +714,11 @@ static bool upgradeDatabase(QSqlDatabase &database)
         QStringList existingTables = findExistingTables(database);
         if (!existingTables.contains(table->name)) {
             if (!addTable(table, database)) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to add table: %1").arg(table->name));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to add table: %1").arg(table->name));
                 error = true;
             } else if (table->postInstall) {
                 if (!(*table->postInstall)(database)) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to run post install function for table: %1").arg(table->name));
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to run post install function for table: %1").arg(table->name));
                     error = true;
                 }
             }
@@ -726,7 +726,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
             if (error) {
                 break;
             } else {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Added table: %1").arg(table->name));
+                QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Added table: %1").arg(table->name));
             }
         }
     }
@@ -738,11 +738,11 @@ static bool upgradeDatabase(QSqlDatabase &database)
             QStringList existingColumns = findExistingColumns(column->table, database);
             if (!existingColumns.contains(column->name)) {
                 if (!addColumn(column, database)) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to add column: %1 to table: %2").arg(column->name).arg(column->table));
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to add column: %1 to table: %2").arg(column->name).arg(column->table));
                     error = true;
                 } else if (column->postInstall) {
                     if (!(*column->postInstall)(database)) {
-                        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to run post install function for column: %1 in table: %2").arg(column->name).arg(column->table));
+                        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to run post install function for column: %1 in table: %2").arg(column->name).arg(column->table));
                         error = true;
                     }
                 }
@@ -750,7 +750,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
                 if (error) {
                     break;
                 } else {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Added column: %1 to table: %2").arg(column->name).arg(column->table));
+                    QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Added column: %1 to table: %2").arg(column->name).arg(column->table));
                 }
             }
         }
@@ -770,7 +770,7 @@ static bool configureDatabase(QSqlDatabase &database)
         || !execute(database, QLatin1String(setupTempStore))
         || !execute(database, QLatin1String(setupJournal))
         || !execute(database, QLatin1String(setupSynchronous))) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to configure contacts database: %1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to configure contacts database: %1")
                 .arg(database.lastError().text()));
         return false;
     }
@@ -792,7 +792,7 @@ static bool prepareDatabase(QSqlDatabase &database)
         QSqlQuery query(database);
 
         if (!query.exec(QLatin1String(createTables[i]))) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Table creation failed: %1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Table creation failed: %1\n%2")
                     .arg(query.lastError().text())
                     .arg(createTables[i]));
             error = true;
@@ -827,13 +827,13 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
     // Create the temporary table (if we haven't already).
     QSqlQuery tableQuery(db);
     if (!tableQuery.prepare(createStatement.arg(table))) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare temporary table query: %1\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare temporary table query: %1\n%2")
                 .arg(tableQuery.lastError().text())
                 .arg(createStatement));
         return false;
     }
     if (!tableQuery.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to create temporary table: %1\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create temporary table: %1\n%2")
                 .arg(tableQuery.lastError().text())
                 .arg(createStatement));
         return false;
@@ -843,13 +843,13 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
     // Delete all existing records.
     QSqlQuery deleteRecordsQuery(db);
     if (!deleteRecordsQuery.prepare(deleteRecordsStatement.arg(table))) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare delete records query: %1\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare delete records query: %1\n%2")
                 .arg(deleteRecordsQuery.lastError().text())
                 .arg(deleteRecordsStatement));
         return false;
     }
     if (!deleteRecordsQuery.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to delete temporary records: %1\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to delete temporary records: %1\n%2")
                 .arg(deleteRecordsQuery.lastError().text())
                 .arg(deleteRecordsStatement));
         return false;
@@ -863,7 +863,7 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
         // specified by filter
         const QString insertStatement = insertFilterStatement.arg(table).arg(join).arg(where).arg(orderBy);
         if (!insertQuery.prepare(insertStatement)) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare temporary contact ids: %1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare temporary contact ids: %1\n%2")
                     .arg(insertQuery.lastError().text())
                     .arg(insertStatement));
             return false;
@@ -872,7 +872,7 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
             insertQuery.bindValue(i, boundValues.at(i));
         }
         if (!insertQuery.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to insert temporary contact ids: %1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to insert temporary contact ids: %1\n%2")
                     .arg(insertQuery.lastError().text())
                     .arg(insertStatement));
             return false;
@@ -887,14 +887,14 @@ bool createTemporaryContactIdsTable(QSqlDatabase &db, const QString &table, bool
         // order of input ids.
         const QString insertStatement = insertIdsStatement.arg(table);
         if (!insertQuery.prepare(insertStatement)) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare temporary contact ids: %1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare temporary contact ids: %1\n%2")
                     .arg(insertQuery.lastError().text())
                     .arg(insertStatement));
             return false;
         }
         insertQuery.bindValue(0, boundIds);
         if (!insertQuery.execBatch()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to insert temporary contact ids: %1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to insert temporary contact ids: %1\n%2")
                     .arg(insertQuery.lastError().text())
                     .arg(insertStatement));
             return false;
@@ -914,12 +914,12 @@ void clearTemporaryContactIdsTable(QSqlDatabase &db, const QString &table)
         QSqlQuery deleteRecordsQuery(db);
         const QString deleteRecordsStatement = QString::fromLatin1("DELETE FROM temp.%1").arg(table);
         if (!deleteRecordsQuery.prepare(deleteRecordsStatement)) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("FATAL ERROR: Failed to prepare delete records query - the next query may return spurious results: %1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare delete records query - the next query may return spurious results: %1\n%2")
                     .arg(deleteRecordsQuery.lastError().text())
                     .arg(deleteRecordsStatement));
         }
         if (!deleteRecordsQuery.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("FATAL ERROR: Failed to delete temporary records - the next query may return spurious results: %1\n%2")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to delete temporary records - the next query may return spurious results: %1\n%2")
                     .arg(deleteRecordsQuery.lastError().text())
                     .arg(deleteRecordsStatement));
         }
@@ -943,7 +943,7 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
     }
 
     if (!databaseDir.exists() && !databaseDir.mkpath(QString::fromLatin1("."))) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to create contacts database directory: %1").arg(databaseDir.path()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to create contacts database directory: %1").arg(databaseDir.path()));
         return QSqlDatabase();
     }
 
@@ -954,13 +954,13 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
     database.setDatabaseName(databaseFile);
 
     if (!database.open()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to open contacts database: %1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to open contacts database: %1")
                 .arg(database.lastError().text()));
         return database;
     }
 
     if (!exists && !prepareDatabase(database)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare contacts database - removing: %1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare contacts database - removing: %1")
                 .arg(database.lastError().text()));
 
         database.close();
@@ -969,7 +969,7 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
         return database;
     } else {
         if (!upgradeDatabase(database)) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to upgrade contacts database: %1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to upgrade contacts database: %1")
                     .arg(database.lastError().text()));
             return database;
         }
@@ -979,7 +979,7 @@ QSqlDatabase ContactsDatabase::open(const QString &databaseName)
         }
     }
 
-    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Opened contacts database: %1").arg(databaseFile));
+    QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Opened contacts database: %1").arg(databaseFile));
     return database;
 }
 
@@ -1003,7 +1003,7 @@ QSqlQuery ContactsDatabase::prepare(const char *statement, const QSqlDatabase &d
     QSqlQuery query(database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare query: %1\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare query: %1\n%2")
                 .arg(query.lastError().text())
                 .arg(statement));
         return QSqlQuery();

--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -611,7 +611,7 @@ public:
             for (;;) {
                 bool pendingJob = false;
                 if (m_currentJob && m_currentJob->request() == request) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Wait for current job: %1 ms").arg(timeout));
+                    QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Wait for current job: %1 ms").arg(timeout));
                     // wait for the current job to updateState.
                     if (!m_finishedWait.wait(&m_mutex, timeout))
                         return false;
@@ -791,7 +791,7 @@ void JobThread::run()
             QElapsedTimer timer;
             timer.start();
             m_currentJob->execute(*m_engine, database, &reader, writer);
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Job executed in %1 ms : %2 : error = %3")
+            QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Job executed in %1 ms : %2 : error = %3")
                     .arg(timer.elapsed()).arg(m_currentJob->description()).arg(m_currentJob->error()));
             locker.relock();
             m_finishedJobs.append(m_currentJob);
@@ -843,7 +843,7 @@ QContactManager::Error ContactsEngine::open()
         ContactNotifier::connect("relationshipsRemoved", "au", this, SLOT(_q_relationshipsRemoved(QVector<quint32>)));
         return QContactManager::NoError;
     } else {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to open database"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to open engine database"));
         return QContactManager::UnspecifiedError;
     }
 }
@@ -1301,7 +1301,7 @@ void ContactsEngine::regenerateDisplayLabel(QContact &contact) const
     QContactManager::Error displayLabelError = QContactManager::NoError;
     QString label = synthesizedDisplayLabel(contact, &displayLabelError);
     if (displayLabelError != QContactManager::NoError) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to regenerate displayLabel for contact: %1").arg(ContactId::toString(contact)));
+        QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Unable to regenerate displayLabel for contact: %1").arg(ContactId::toString(contact)));
         return;
     }
 

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -613,7 +613,7 @@ ContactWriter::ContactWriter(const ContactsEngine &engine, const QSqlDatabase &d
         m_findAggregateForContactIds = prepare(findAggregateForContactIds, database);
         m_selectAggregateContactIds = prepare(selectAggregateContactIds, database);
     } else {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare temporary aggregationIds table"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare temporary aggregationIds table"));
     }
 }
 
@@ -640,7 +640,7 @@ bool ContactWriter::beginTransaction()
 bool ContactWriter::commitTransaction()
 {
     if (!ContactsDatabase::commitTransaction(m_database)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Commit error: %1").arg(m_database.lastError().text()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Commit error: %1").arg(m_database.lastError().text()));
         rollbackTransaction();
         return false;
     }
@@ -648,7 +648,7 @@ bool ContactWriter::commitTransaction()
     if (m_databaseMutex->isLocked()) {
         m_databaseMutex->unlock();
     } else {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Lock error: no lock held on commit"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Lock error: no lock held on commit"));
     }
 
     if (!m_addedIds.isEmpty()) {
@@ -672,7 +672,7 @@ void ContactWriter::rollbackTransaction()
     if (m_databaseMutex->isLocked()) {
         m_databaseMutex->unlock();
     } else {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Lock error: no lock held on rollback"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Lock error: no lock held on rollback"));
     }
 
     m_removedIds.clear();
@@ -781,7 +781,7 @@ QContactManager::Error ContactWriter::save(
         return QContactManager::NoError;
 
     if (!withinTransaction && !beginTransaction()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to begin database transaction while saving relationships"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to begin database transaction while saving relationships"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -795,7 +795,7 @@ QContactManager::Error ContactWriter::save(
     }
 
     if (!withinTransaction && !commitTransaction()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to commit database after relationship save"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to commit database after relationship save"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -825,7 +825,7 @@ QContactManager::Error ContactWriter::saveRelationships(
     QMultiMap<quint32, QPair<QString, quint32> > bucketedRelationships; // first id to <type, second id>.
     {
         if (!m_existingRelationships.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch existing relationships for duplicate detection during insert:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch existing relationships for duplicate detection during insert:\n%1")
                     .arg(m_existingRelationships.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
@@ -845,7 +845,7 @@ QContactManager::Error ContactWriter::saveRelationships(
     QSet<quint32> validContactIds;
     {
         if (!m_existingContactIds.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch existing contacts for validity detection during insert:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch existing contacts for validity detection during insert:\n%1")
                     .arg(m_existingContactIds.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
@@ -934,7 +934,7 @@ QContactManager::Error ContactWriter::saveRelationships(
     }
 
     if (realInsertions > 0 && !multiInsertQuery.prepare(queryString)) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare multiple insert relationships query:\n%1\nQuery:\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare multiple insert relationships query:\n%1\nQuery:\n%2")
                 .arg(multiInsertQuery.lastError().text())
                 .arg(queryString));
         return QContactManager::UnspecifiedError;
@@ -947,7 +947,7 @@ QContactManager::Error ContactWriter::saveRelationships(
     }
 
     if (realInsertions > 0 && !multiInsertQuery.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to insert relationships:\n%1\nQuery:\n%2")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to insert relationships:\n%1\nQuery:\n%2")
                 .arg(multiInsertQuery.lastError().text())
                 .arg(queryString));
         return QContactManager::UnspecifiedError;
@@ -973,7 +973,7 @@ QContactManager::Error ContactWriter::remove(
         return QContactManager::NoError;
 
     if (!withinTransaction && !beginTransaction()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to begin database transaction while removing relationships"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to begin database transaction while removing relationships"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -987,7 +987,7 @@ QContactManager::Error ContactWriter::remove(
     }
 
     if (!withinTransaction && !commitTransaction()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to commit database after relationship removal"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to commit database after relationship removal"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -1001,7 +1001,7 @@ QContactManager::Error ContactWriter::removeRelationships(
     QMultiMap<quint32, QPair<QString, quint32> > bucketedRelationships; // first id to <type, second id>.
     {
         if (!m_existingRelationships.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch existing relationships for duplicate detection during insert:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch existing relationships for duplicate detection during insert:\n%1")
                     .arg(m_existingRelationships.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
@@ -1040,7 +1040,7 @@ QContactManager::Error ContactWriter::removeRelationships(
 
         QSqlQuery removeRelationship(m_database);
         if (!removeRelationship.prepare("DELETE FROM Relationships WHERE firstId = :firstId AND secondId = :secondId AND type = :type;")) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to prepare remove relationship:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to prepare remove relationship:\n%1")
                     .arg(removeRelationship.lastError().text()));
             worstError = QContactManager::UnspecifiedError;
             if (errorMap)
@@ -1062,7 +1062,7 @@ QContactManager::Error ContactWriter::removeRelationships(
 #endif
 
         if (!removeRelationship.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to remove relationship:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to remove relationship:\n%1")
                     .arg(removeRelationship.lastError().text()));
             worstError = QContactManager::UnspecifiedError;
             if (errorMap)
@@ -1111,7 +1111,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
     quint32 selfContactId = 0;
     m_selfContactId.bindValue(":identity", ContactsDatabase::SelfContactId);
     if (!m_selfContactId.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch self contact id during remove:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch self contact id during remove:\n%1")
                 .arg(m_selfContactId.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -1125,7 +1125,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
     // shouldn't care (ie, not exists == has been removed).
     QSet<quint32> existingContactIds;
     if (!m_existingContactIds.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch existing contact ids during remove:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch existing contact ids during remove:\n%1")
                 .arg(m_existingContactIds.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -1161,12 +1161,12 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
     if (realRemoveIds.size() > 0) {
         if (!withinTransaction && !beginTransaction()) {
             // if we are not already within a transaction, create a transaction.
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to begin database transaction while removing contacts"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to begin database transaction while removing contacts"));
             return QContactManager::UnspecifiedError;
         }
         m_removeContact.bindValue(QLatin1String(":contactId"), boundRealRemoveIds);
         if (!m_removeContact.execBatch()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to remove contacts:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to remove contacts:\n%1")
                     .arg(m_removeContact.lastError().text()));
             if (!withinTransaction) {
                 // only rollback if we created a transaction.
@@ -1180,7 +1180,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
         }
         if (!withinTransaction && !commitTransaction()) {
             // only commit if we created a transaction.
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to commit removal"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to commit removal"));
             return QContactManager::UnspecifiedError;
         }
     }
@@ -1198,7 +1198,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
     } else {
         // Use the temporary table for both queries
         if (!m_selectAggregateContactIds.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to select aggregate contact ids during remove:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to select aggregate contact ids during remove:\n%1")
                     .arg(m_selectAggregateContactIds.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
@@ -1208,7 +1208,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
         m_selectAggregateContactIds.finish();
 
         if (!m_findAggregateForContactIds.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch aggregator contact ids during remove:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch aggregator contact ids during remove:\n%1")
                     .arg(m_findAggregateForContactIds.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
@@ -1233,7 +1233,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
 
     if (!withinTransaction && !beginTransaction()) {
         // only create a transaction if we're not already within one
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to begin database transaction while removing contacts"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to begin database transaction while removing contacts"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -1241,7 +1241,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
     if (boundNonAggregatesToRemove.size() > 0) {
         m_removeContact.bindValue(QLatin1String(":contactId"), boundNonAggregatesToRemove);
         if (!m_removeContact.execBatch()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to removed non-aggregate contacts:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to removed non-aggregate contacts:\n%1")
                     .arg(m_removeContact.lastError().text()));
             if (!withinTransaction) {
                 // only rollback the transaction if we created it
@@ -1263,7 +1263,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
             return QContactManager::UnspecifiedError;
         } else {
             if (!m_findConstituentsForAggregateIds.exec()) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch contacts aggregated by removed aggregates:\n%1")
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch contacts aggregated by removed aggregates:\n%1")
                         .arg(m_findConstituentsForAggregateIds.lastError().text()));
                 if (!withinTransaction) {
                     // only rollback the transaction if we created it
@@ -1282,7 +1282,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
         // remove the aggregates + the aggregated
         m_removeContact.bindValue(QLatin1String(":contactId"), boundAggregatesToRemove);
         if (!m_removeContact.execBatch()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to removed aggregate contacts (and the contacts they aggregate):\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to removed aggregate contacts (and the contacts they aggregate):\n%1")
                     .arg(m_removeContact.lastError().text()));
             if (!withinTransaction) {
                 // only rollback the transaction if we created it
@@ -1321,7 +1321,7 @@ QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contac
 
     // Success!  If we created a transaction, commit.
     if (!withinTransaction && !commitTransaction()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to commit database after removal"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to commit database after removal"));
         return QContactManager::UnspecifiedError;
     }
 
@@ -1504,7 +1504,7 @@ template <typename T> bool ContactWriter::removeCommonDetails(
     m_removeDetail.bindValue(1, detailTypeName<T>());
 
     if (!m_removeDetail.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to remove common detail for %1:\n%2").arg(detailTypeName<T>())
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to remove common detail for %1:\n%2").arg(detailTypeName<T>())
                 .arg(m_removeDetail.lastError().text()));
         *error = QContactManager::UnspecifiedError;
         return false;
@@ -1696,7 +1696,7 @@ template <typename T> bool ContactWriter::writeCommonDetails(
     m_insertDetail.bindValue(8, modifiable);
 
     if (!m_insertDetail.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to write common details for %1:\n%2\ndetailUri: %3, linkedDetailUris: %4")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to write common details for %1:\n%2\ndetailUri: %3, linkedDetailUris: %4")
                 .arg(detailTypeName<T>())
                 .arg(m_insertDetail.lastError().text())
                 .arg(detailUri.value<QString>())
@@ -1725,7 +1725,7 @@ template <typename T> bool ContactWriter::writeDetails(
 
     removeQuery.bindValue(0, contactId);
     if (!removeQuery.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to remove existing details for %1:\n%2").arg(detailTypeName<T>())
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to remove existing details for %1:\n%2").arg(detailTypeName<T>())
                 .arg(removeQuery.lastError().text()));
         *error = QContactManager::UnspecifiedError;
         return false;
@@ -1738,7 +1738,7 @@ template <typename T> bool ContactWriter::writeDetails(
         T &detail(*it);
         QSqlQuery &query = bindDetail(contactId, detail);
         if (!query.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to write details for %1:\n%2").arg(detailTypeName<T>())
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to write details for %1:\n%2").arg(detailTypeName<T>())
                     .arg(query.lastError().text()));
             *error = QContactManager::UnspecifiedError;
             return false;
@@ -1803,7 +1803,7 @@ QContactManager::Error ContactWriter::save(
             if (batchSyncTarget.isEmpty()) {
                 batchSyncTarget = currSyncTarget;
             } else if (batchSyncTarget != currSyncTarget) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Error: contacts from multiple sync targets specified in single batch save!"));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Error: contacts from multiple sync targets specified in single batch save!"));
                 return QContactManager::UnspecifiedError;
             }
         }
@@ -1811,14 +1811,14 @@ QContactManager::Error ContactWriter::save(
 
     if (!withinTransaction && !beginTransaction()) {
         // only create a transaction if we're not within one already
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to begin database transaction while saving contacts"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to begin database transaction while saving contacts"));
         return QContactManager::UnspecifiedError;
     }
 
     // Find the maximum possible aggregate contact id.
     // This assumes that no two contacts from the same synctarget should be aggregated together.
     if (!m_findMaximumContactId.exec() || !m_findMaximumContactId.next()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to find max possible aggregate during batch save: %1").arg(m_findMaximumContactId.lastError().text()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to find max possible aggregate during batch save: %1").arg(m_findMaximumContactId.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
     int maxAggregateId = m_findMaximumContactId.value(0).toInt();
@@ -1835,14 +1835,14 @@ QContactManager::Error ContactWriter::save(
             if (err == QContactManager::NoError) {
                 m_addedIds.insert(ContactId::apiId(contact));
             } else {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Error creating contact: %1 syncTarget: %2").arg(err).arg(contact.detail<QContactSyncTarget>().syncTarget()));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Error creating contact: %1 syncTarget: %2").arg(err).arg(contact.detail<QContactSyncTarget>().syncTarget()));
             }
         } else {
             err = update(&contact, definitionMask, &aggregateUpdated, true, withinAggregateUpdate);
             if (err == QContactManager::NoError) {
                 m_changedIds.insert(contactId);
             } else {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Error updating contact %1: %2").arg(ContactId::toString(contactId)).arg(err));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Error updating contact %1: %2").arg(ContactId::toString(contactId)).arg(err));
             }
         }
         if (aggregatesUpdated) {
@@ -1879,7 +1879,7 @@ QContactManager::Error ContactWriter::save(
             rollbackTransaction();
             return worstError;
         } else if (!commitTransaction()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to commit contacts"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to commit contacts"));
             return QContactManager::UnspecifiedError;
         }
     }
@@ -1963,7 +1963,7 @@ static QContactManager::Error enforceDetailConstraints(QContact *contact)
     foreach (const QContactDetail &det, contact->details()) {
         QString typeName(detailTypeName(det));
         if (!detailListContains(supported, det)) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Invalid detail type: %1").arg(typeName));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Invalid detail type: %1").arg(typeName));
             return QContactManager::InvalidDetailError;
         } else {
             ++detailCounts[detailType(det)];
@@ -1973,7 +1973,7 @@ static QContactManager::Error enforceDetailConstraints(QContact *contact)
     // enforce uniqueness constraints
     foreach (const ContactWriter::DetailList::value_type &type, singular) {
         if (detailCounts[type] > 1) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Invalid count of detail type %1: %2").arg(detailTypeName(type)).arg(detailCounts[type]));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Invalid count of detail type %1: %2").arg(detailTypeName(type)).arg(detailCounts[type]));
             return QContactManager::LimitReachedError;
         }
     }
@@ -2162,7 +2162,7 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
     QList<QContact> writeList;
     QContactManager::Error deltaError = calculateDelta(contact, definitionMask, &addDeltaDetails, &remDeltaDetails, &writeList);
     if (deltaError != QContactManager::NoError) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to calculate delta for modified aggregate"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to calculate delta for modified aggregate"));
         return deltaError;
     }
 
@@ -2176,7 +2176,7 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
     if (!addDeltaDetails.isEmpty() || !remDeltaDetails.isEmpty()) {
         m_findLocalForAggregate.bindValue(":aggregateId", ContactId::databaseId(contact->id()));
         if (!m_findLocalForAggregate.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to query local for aggregate during update:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to query local for aggregate during update:\n%1")
                     .arg(m_findLocalForAggregate.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
@@ -2194,7 +2194,7 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
             QList<QContact> readList;
             QContactManager::Error readError = m_reader->readContacts(QLatin1String("UpdateAggregate"), &readList, whichList, hint);
             if (readError != QContactManager::NoError || readList.size() == 0) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to read local contact for aggregate %1 during update")
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to read local contact for aggregate %1 during update")
                         .arg(ContactId::toString(*contact)));
                 return readError == QContactManager::NoError ? QContactManager::UnspecifiedError : readError;
             }
@@ -2227,7 +2227,7 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
                                              &aggregatesUpdated, &errorMap,  // because it might be a new contact and need name+synct.
                                              withinTransaction, true);
     if (writeError != QContactManager::NoError) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to update (or create) local contact for modified aggregate"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to update (or create) local contact for modified aggregate"));
         return writeError;
     }
 
@@ -2239,7 +2239,7 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
         if (writeError != QContactManager::NoError) {
             // TODO: remove unaggregated contact
             // if the aggregation relationship fails, the entire save has failed.
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to save aggregation relationship for new local contact!"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to save aggregation relationship for new local contact!"));
             return writeError;
         }
     }
@@ -2254,13 +2254,13 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
         writeList.append(*contact);
         writeError = save(&writeList, definitionMask, 0, &errorMap, withinTransaction, true); // we're updating the aggregate contact deliberately.
         if (writeError != QContactManager::NoError) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to update modified aggregate"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to update modified aggregate"));
             if (createdNewLocal) {
                 QList<QContactIdType> removeList;
                 removeList.append(ContactId::apiId(localContact));
                 QContactManager::Error removeError = remove(removeList, &errorMap, withinTransaction);
                 if (removeError != QContactManager::NoError) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to remove stale local contact created for modified aggregate"));
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to remove stale local contact created for modified aggregate"));
                 }
             }
         }
@@ -2585,7 +2585,7 @@ QContactManager::Error ContactWriter::calculateDelta(QContact *contact, const Co
 
             m_modifiableDetails.bindValue(":contactId", contactId);
             if (!m_modifiableDetails.exec()) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to select modifiable details for contact %1:\n%2").arg(contactId)
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to select modifiable details for contact %1:\n%2").arg(contactId)
                         .arg(m_modifiableDetails.lastError().text()));
             } else {
                 while (m_modifiableDetails.next()) {
@@ -2648,11 +2648,11 @@ QContactManager::Error ContactWriter::calculateDelta(QContact *contact, const Co
             QMap<quint32, QContact *>::iterator cit = updatedContacts.find(rit.key());
             if (cit != updatedContacts.end()) {
                 if (!removeContactDetails(cit.value(), rit.value())) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to remove details from constituent contact: %1").arg(cit.key()));
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to remove details from constituent contact: %1").arg(cit.key()));
                     return QContactManager::UnspecifiedError;
                 }
             } else {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to find constituent contact to remove detail: %1").arg(rit.key()));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to find constituent contact to remove detail: %1").arg(rit.key()));
                 return QContactManager::UnspecifiedError;
             }
         }
@@ -2663,11 +2663,11 @@ QContactManager::Error ContactWriter::calculateDelta(QContact *contact, const Co
             QMap<quint32, QContact *>::iterator cit = updatedContacts.find(mit.key());
             if (cit != updatedContacts.end()) {
                 if (!modifyContactDetails(cit.value(), mit.value())) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to remove details from constituent contact: %1").arg(cit.key()));
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to remove details from constituent contact: %1").arg(cit.key()));
                     return QContactManager::UnspecifiedError;
                 }
             } else {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to find constituent contact to remove detail: %1").arg(mit.key()));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to find constituent contact to remove detail: %1").arg(mit.key()));
                 return QContactManager::UnspecifiedError;
             }
         }
@@ -2767,7 +2767,7 @@ QContactManager::Error ContactWriter::updateOrCreateAggregate(QContact *contact,
     bool found = false;
 
     if (!m_findMatchForContact.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("error finding match for updated local contact:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Error finding match for updated local contact:\n%1")
                 .arg(m_findMatchForContact.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -2787,7 +2787,7 @@ QContactManager::Error ContactWriter::updateOrCreateAggregate(QContact *contact,
             QList<QContact> readList;
             QContactManager::Error readError = m_reader->readContacts(QLatin1String("CreateAggregate"), &readList, readIds, hint);
             if (readError != QContactManager::NoError || readList.size() < 1) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to read aggregate contact %1 during regenerate").arg(ContactId::toString(aggregateId)));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to read aggregate contact %1 during regenerate").arg(ContactId::toString(aggregateId)));
                 return QContactManager::UnspecifiedError;
             }
 
@@ -2812,9 +2812,9 @@ QContactManager::Error ContactWriter::updateOrCreateAggregate(QContact *contact,
     QContactManager::Error err = save(&saveContactList, DetailList(), 0, &errorMap, withinTransaction, true); // we're updating (or creating) the aggregate
     if (err != QContactManager::NoError) {
         if (!found) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Could not create new aggregate contact"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Could not create new aggregate contact"));
         } else {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Could not update existing aggregate contact"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Could not update existing aggregate contact"));
         }
         return err;
     }
@@ -2829,13 +2829,13 @@ QContactManager::Error ContactWriter::updateOrCreateAggregate(QContact *contact,
     m_insertRelationship.bindValue(":secondId", ContactId::databaseId(*contact));
     m_insertRelationship.bindValue(":type", relationshipString(QContactRelationship::Aggregates));
     if (!m_insertRelationship.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("error inserting Aggregates relationship: %1").arg(m_insertRelationship.lastError().text()));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Error inserting Aggregates relationship: %1").arg(m_insertRelationship.lastError().text()));
         err = QContactManager::UnspecifiedError;
     }
 
     if (err != QContactManager::NoError) {
         // if the aggregation relationship fails, the entire save has failed.
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to save aggregation relationship!"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to save aggregation relationship!"));
 
         if (!found) {
             // clean up the newly created contact.
@@ -2843,7 +2843,7 @@ QContactManager::Error ContactWriter::updateOrCreateAggregate(QContact *contact,
             removeList.append(ContactId::apiId(matchingAggregate));
             QContactManager::Error cleanupErr = remove(removeList, &errorMap, withinTransaction);
             if (cleanupErr != QContactManager::NoError) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to cleanup newly created aggregate contact!"));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to cleanup newly created aggregate contact!"));
             }
         }
     }
@@ -2885,7 +2885,7 @@ void ContactWriter::regenerateAggregates(const QList<quint32> &aggregateIds, con
 
         m_findConstituentsForAggregate.bindValue(":aggregateId", aggId);
         if (!m_findConstituentsForAggregate.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to find constituent contacts for aggregate %1 during regenerate").arg(aggId));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to find constituent contacts for aggregate %1 during regenerate").arg(aggId));
             continue;
         }
         while (m_findConstituentsForAggregate.next()) {
@@ -2894,7 +2894,7 @@ void ContactWriter::regenerateAggregates(const QList<quint32> &aggregateIds, con
         m_findConstituentsForAggregate.finish();
 
         if (readIds.size() == 1) { // only the aggregate?
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Existing aggregate %1 should already have been removed - aborting regenerate").arg(aggId));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Existing aggregate %1 should already have been removed - aborting regenerate").arg(aggId));
             continue;
         }
 
@@ -2906,7 +2906,7 @@ void ContactWriter::regenerateAggregates(const QList<quint32> &aggregateIds, con
         if (readError != QContactManager::NoError
                 || readList.size() <= 1
                 || readList.at(0).detail<QContactSyncTarget>().value(QContactSyncTarget::FieldSyncTarget) != aggregateSyncTarget) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to read constituent contacts for aggregate %1 during regenerate").arg(aggId));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to read constituent contacts for aggregate %1 during regenerate").arg(aggId));
             continue;
         }
 
@@ -2924,7 +2924,7 @@ void ContactWriter::regenerateAggregates(const QList<quint32> &aggregateIds, con
                 // Copy this detail to the new aggregate
                 QContactDetail newDetail(detail);
                 if (!aggregateContact.saveDetail(&newDetail)) {
-                    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Contact: %1 Failed to copy existing detail:")
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Contact: %1 Failed to copy existing detail:")
                             .arg(ContactId::toString(aggregateContact)) << detail);
                 }
             }
@@ -2967,7 +2967,7 @@ void ContactWriter::regenerateAggregates(const QList<quint32> &aggregateIds, con
     QMap<int, QContactManager::Error> errorMap;
     QContactManager::Error writeError = save(&aggregatesToSave, DetailList(), 0, &errorMap, withinTransaction, true); // we're updating aggregates.
     if (writeError != QContactManager::NoError) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to write updated aggregate contacts during regenerate.  definitionMask:") << definitionMask);
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to write updated aggregate contacts during regenerate.  definitionMask:") << definitionMask);
     }
 }
 
@@ -2975,7 +2975,7 @@ QContactManager::Error ContactWriter::removeChildlessAggregates(QList<QContactId
 {
     QVariantList aggregateIds;
     if (!m_childlessAggregateIds.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch childless aggregate contact ids during remove:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch childless aggregate contact ids during remove:\n%1")
                 .arg(m_childlessAggregateIds.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -2989,7 +2989,7 @@ QContactManager::Error ContactWriter::removeChildlessAggregates(QList<QContactId
     if (aggregateIds.size() > 0) {
         m_removeContact.bindValue(QLatin1String(":contactId"), aggregateIds);
         if (!m_removeContact.execBatch()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to remove childless aggregate contacts:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to remove childless aggregate contacts:\n%1")
                     .arg(m_removeContact.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
@@ -3003,7 +3003,7 @@ QContactManager::Error ContactWriter::aggregateOrphanedContacts(bool withinTrans
 {
     QList<QContactIdType> contactIds;
     if (!m_orphanContactIds.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch orphan aggregate contact ids during remove:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch orphan aggregate contact ids during remove:\n%1")
                 .arg(m_orphanContactIds.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -3020,12 +3020,12 @@ QContactManager::Error ContactWriter::aggregateOrphanedContacts(bool withinTrans
         QList<QContact> readList;
         QContactManager::Error readError = m_reader->readContacts(QLatin1String("AggregateOrphaned"), &readList, contactIds, hint);
         if (readError != QContactManager::NoError || readList.size() != contactIds.size()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to read orphaned contacts for aggregation"));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to read orphaned contacts for aggregation"));
             return QContactManager::UnspecifiedError;
         }
 
         if (!m_findMaximumContactId.exec() || !m_findMaximumContactId.next()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to find max possible aggregate for orphan: %1").arg(m_findMaximumContactId.lastError().text()));
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to find max possible aggregate for orphan: %1").arg(m_findMaximumContactId.lastError().text()));
             return QContactManager::UnspecifiedError;
         }
         int maxAggregateId = m_findMaximumContactId.value(0).toInt();
@@ -3036,7 +3036,7 @@ QContactManager::Error ContactWriter::aggregateOrphanedContacts(bool withinTrans
             QContact &orphan(*it);
             QContactManager::Error error = updateOrCreateAggregate(&orphan, DetailList(), maxAggregateId, withinTransaction);
             if (error != QContactManager::NoError) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to create aggregate for orphaned contact: %1").arg(ContactId::toString(orphan)));
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create aggregate for orphaned contact: %1").arg(ContactId::toString(orphan)));
                 return error;
             }
         }
@@ -3126,13 +3126,13 @@ QContactManager::Error ContactWriter::create(QContact *contact, const DetailList
 
     QContactManager::Error writeErr = enforceDetailConstraints(contact);
     if (writeErr != QContactManager::NoError) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Contact failed detail constraints"));
+        QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Contact failed detail constraints"));
         return writeErr;
     }
 
     bindContactDetails(*contact, m_insertContact, DetailList(), false);
     if (!m_insertContact.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to create contact:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to create contact:\n%1")
                 .arg(m_insertContact.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -3158,7 +3158,7 @@ QContactManager::Error ContactWriter::create(QContact *contact, const DetailList
         // error occurred.  Remove the failed entry.
         m_removeContact.bindValue(":contactId", contactId);
         if (!m_removeContact.exec()) {
-            QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Unable to remove stale contact after failed save:\n%1")
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to remove stale contact after failed save:\n%1")
                     .arg(m_removeContact.lastError().text()));
         }
         m_removeContact.finish();
@@ -3179,7 +3179,7 @@ QContactManager::Error ContactWriter::update(QContact *contact, const DetailList
 
     m_checkContactExists.bindValue(0, contactId);
     if (!m_checkContactExists.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to check contact existence:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to check contact existence:\n%1")
                 .arg(m_checkContactExists.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -3196,13 +3196,13 @@ QContactManager::Error ContactWriter::update(QContact *contact, const DetailList
     if (newSyncTarget != oldSyncTarget &&
         (oldSyncTarget != localSyncTarget && oldSyncTarget != wasLocalSyncTarget)) {
         // they are attempting to manually change the sync target value of a non-local contact
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Cannot manually change sync target!"));
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Cannot manually change sync target!"));
         return QContactManager::InvalidDetailError;
     }
 
     QContactManager::Error writeError = enforceDetailConstraints(contact);
     if (writeError != QContactManager::NoError) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Contact failed detail constraints"));
+        QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Contact failed detail constraints"));
         return writeError;
     }
 
@@ -3231,7 +3231,7 @@ QContactManager::Error ContactWriter::update(QContact *contact, const DetailList
     bindContactDetails(*contact, m_updateContact, definitionMask, true);
     m_updateContact.bindValue(22, contactId);
     if (!m_updateContact.exec()) {
-        QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to update contact:\n%1")
+        QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to update contact:\n%1")
                 .arg(m_updateContact.lastError().text()));
         return QContactManager::UnspecifiedError;
     }
@@ -3245,7 +3245,7 @@ QContactManager::Error ContactWriter::update(QContact *contact, const DetailList
             QList<quint32> aggregatesOfUpdated;
             m_findAggregateForContact.bindValue(":localId", contactId);
             if (!m_findAggregateForContact.exec()) {
-                QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("Failed to fetch aggregator contact ids during remove:\n%1")
+                QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed to fetch aggregator contact ids during remove:\n%1")
                         .arg(m_findAggregateForContact.lastError().text()));
                 return QContactManager::UnspecifiedError;
             }

--- a/src/engine/semaphore_p.cpp
+++ b/src/engine/semaphore_p.cpp
@@ -142,6 +142,6 @@ int Semaphore::value() const
 
 void Semaphore::error(const char *msg, int error)
 {
-    QTCONTACTS_SQLITE_DEBUG_TRACE(QString::fromLatin1("%1 %2: %3 (%4)").arg(msg).arg(m_identifier).arg(::strerror(error)).arg(error));
+    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("%1 %2: %3 (%4)").arg(msg).arg(m_identifier).arg(::strerror(error)).arg(error));
 }
 

--- a/src/engine/trace_p.h
+++ b/src/engine/trace_p.h
@@ -41,11 +41,17 @@ static bool qtcontacts_sqlite_debug_trace_enabled()
     return traceEnabled;
 }
 
-#define QTCONTACTS_SQLITE_DEBUG_TRACE(msg)                         \
+#define QTCONTACTS_SQLITE_DEBUG(msg)                               \
     do {                                                           \
         if (Q_UNLIKELY(qtcontacts_sqlite_debug_trace_enabled())) { \
             qWarning() << msg;                                     \
         }                                                          \
     } while (0)
 
+#define QTCONTACTS_SQLITE_WARNING(msg)    \
+    do {                                  \
+        qWarning() << msg;                \
+    } while (0)
+
 #endif
+


### PR DESCRIPTION
It shouldn't be necessary to configure warnings to be reported.
