### PR TITLE
[qtcontacts-sqlite] Enforce single threaded access to contacts database

### DIFF
--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -1503,6 +1503,8 @@ QContactManager::Error ContactReader::readContacts(
         const QList<QContactSortOrder> &order,
         const QContactFetchHint &fetchHint)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     QString join;
     const QString orderBy = buildOrderBy(order, &join);
     bool whereFailed = false;
@@ -1531,6 +1533,8 @@ QContactManager::Error ContactReader::readContacts(
         const QList<QContactIdType> &contactIds,
         const QContactFetchHint &fetchHint)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     QVariantList boundIds;
     for (int i = 0; i < contactIds.size(); ++i) {
         boundIds.append(ContactId::databaseId(contactIds.at(i)));
@@ -1809,6 +1813,8 @@ QContactManager::Error ContactReader::readContactIds(
         const QContactFilter &filter,
         const QList<QContactSortOrder> &order)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     QString join;
     const QString orderBy = buildOrderBy(order, &join);
     bool failed = false;
@@ -1862,6 +1868,8 @@ QContactManager::Error ContactReader::readContactIds(
 QContactManager::Error ContactReader::getIdentity(
         ContactsDatabase::Identity identity, QContactIdType *contactId)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     if (identity == ContactsDatabase::SelfContactId) {
         // we don't allow setting the self contact id, it's always static
         *contactId = selfId;
@@ -1891,6 +1899,8 @@ QContactManager::Error ContactReader::readRelationships(
         const QContactId &first,
         const QContactId &second)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     QStringList whereStatements;
     QVariantList bindings;
     if (!type.isEmpty()) {

--- a/src/engine/contactsdatabase.h
+++ b/src/engine/contactsdatabase.h
@@ -32,6 +32,7 @@
 #ifndef QTCONTACTSSQLITE_CONTACTSDATABASE
 #define QTCONTACTSSQLITE_CONTACTSDATABASE
 
+#include <QMutex>
 #include <QSqlDatabase>
 #include <QVariantList>
 
@@ -58,6 +59,8 @@ public:
     static QString expandQuery(const QString &queryString, const QVariantList &bindings);
     static QString expandQuery(const QString &queryString, const QMap<QString, QVariant> &bindings);
     static QString expandQuery(const QSqlQuery &query);
+
+    static QMutex *accessMutex();
 };
 
 #endif

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -719,6 +719,8 @@ void ContactWriter::rollbackTransaction()
 QContactManager::Error ContactWriter::setIdentity(
         ContactsDatabase::Identity identity, QContactIdType contactId)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     QSqlQuery *query = 0;
 
     quint32 dbId = ContactId::databaseId(contactId);
@@ -813,6 +815,8 @@ static QContactManager::Error bindRelationships(
 QContactManager::Error ContactWriter::save(
         const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap, bool withinTransaction)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     if (relationships.isEmpty())
         return QContactManager::NoError;
 
@@ -1005,6 +1009,8 @@ QContactManager::Error ContactWriter::saveRelationships(
 QContactManager::Error ContactWriter::remove(
         const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap, bool withinTransaction)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     if (relationships.isEmpty())
         return QContactManager::NoError;
 
@@ -1140,6 +1146,8 @@ QContactManager::Error ContactWriter::removeRelationships(
 
 QContactManager::Error ContactWriter::remove(const QList<QContactIdType> &contactIds, QMap<int, QContactManager::Error> *errorMap, bool withinTransaction)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     if (contactIds.isEmpty())
         return QContactManager::NoError;
 
@@ -1824,6 +1832,8 @@ QContactManager::Error ContactWriter::save(
             bool withinTransaction,
             bool withinAggregateUpdate)
 {
+    QMutexLocker locker(ContactsDatabase::accessMutex());
+
     if (contacts->isEmpty())
         return QContactManager::NoError;
 


### PR DESCRIPTION
Ensure that only one thread is accessing the contacts SQLite database
at any given time.
