### PR TITLE
[qtcontacts-sqlite] Increase the maximum digits used in minimized phone ...

### DIFF
--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -1320,7 +1320,7 @@ bool ContactsEngine::setContactDisplayLabel(QContact *contact, const QString &la
 QString ContactsEngine::normalizedPhoneNumber(const QString &input)
 {
     // TODO: Use a configuration variable to specify max characters:
-    static const int maxCharacters = 7;
+    static const int maxCharacters = QtContactsSqliteExtensions::DefaultMaximumPhoneNumberCharacters;
 
     return QtContactsSqliteExtensions::minimizePhoneNumber(input, maxCharacters);
 }

--- a/src/extensions/qtcontacts-extensions.h
+++ b/src/extensions/qtcontacts-extensions.h
@@ -136,8 +136,10 @@ enum NormalizePhoneNumberFlag {
 };
 Q_DECLARE_FLAGS(NormalizePhoneNumberFlags, NormalizePhoneNumberFlag)
 
+enum { DefaultMaximumPhoneNumberCharacters = 8 };
+
 QString normalizePhoneNumber(const QString &input, NormalizePhoneNumberFlags flags);
-QString minimizePhoneNumber(const QString &input, int maxCharacters = 7);
+QString minimizePhoneNumber(const QString &input, int maxCharacters = DefaultMaximumPhoneNumberCharacters);
 
 }
 

--- a/src/qtcontacts-sqlite-extensions.pc
+++ b/src/qtcontacts-sqlite-extensions.pc
@@ -3,5 +3,5 @@ includedir=${prefix}/include/qtcontacts-sqlite-extensions
 
 Name: qtcontacts-sqlite-extensions
 Description: QtContacts extensions implemented by qtcontacts-sqlite
-Version: 0.1.16
+Version: 0.1.27
 Cflags:  -I${includedir}

--- a/src/qtcontacts-sqlite-qt5-extensions.pc
+++ b/src/qtcontacts-sqlite-qt5-extensions.pc
@@ -3,5 +3,5 @@ includedir=${prefix}/include/qtcontacts-sqlite-qt5-extensions
 
 Name: qtcontacts-sqlite-qt5-extensions
 Description: QtContacts extensions implemented by qtcontacts-sqlite-qt5
-Version: 0.1.16
+Version: 0.1.27
 Cflags:  -I${includedir}


### PR DESCRIPTION
...numbers

Although 7 digits is typically enough to differentiate phone numbers
in their local forms, an eighth digit is sometimes required to
differentiate between a local number and the voicemail service for
that number.
