### PR TITLE
[qtcontacts-sqlite] Fix: Check for read/write capability using QFileInfo

### DIFF
--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -961,12 +961,11 @@ void clearTemporaryContactIdsTable(QSqlDatabase &db, const QString &table)
     }
 }
 
-// QDir::isReadable() doesn't support group permissions, only user permissions.
+// There is no QDir::isWritable()/isExecutable(). Only isReadable() is part of QDir.
 bool directoryIsRW(const QString &dirPath)
 {
-  QFileInfo databaseDirInfo(dirPath);
-  return (databaseDirInfo.permission(QFile::ReadGroup | QFile::WriteGroup)
-       || databaseDirInfo.permission(QFile::ReadUser  | QFile::WriteUser));
+  QFileInfo dirInfo(dirPath);
+  return dirInfo.isReadable() && dirInfo.isWritable() && dirInfo.isExecutable();
 }
 
 QSqlDatabase ContactsDatabase::open(const QString &databaseName)


### PR DESCRIPTION
This fixes e4f626a (Check for read/write capability using QFileInfo).

Met the bug while executing commhistory-daemon tests.

QFileInfo::permission(QFile::ReadGroup | QFile::WriteGroup) only checks
file permission bits. It does not honor process' GID. As a result it
always claims the 'privileged' directory is RW to the user, as it is
installed with 0070 mode set.

Note that there is also difference between corresponding QFile::_User
and QFile::_Owner R/W/X flags and it seems Qt API documentation is not
accurate about this - the note about platform difference between Windows
and Unix seems to not be true anymore (not sure though).

Comment replaced because QDir::isReadable() actually supports group
permissions, but there is no QDir::isWritable().
