### PR TITLE
[qtcontacts-sqlite] Sort presence states by availability

### DIFF
--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -1809,6 +1809,28 @@ template <typename T> bool ContactWriter::writeDetails(
     return true;
 }
 
+static int presenceOrder(QContactPresence::PresenceState state)
+{
+#ifdef SORT_PRESENCE_BY_AVAILABILITY
+    if (state == QContactPresence::PresenceAvailable) {
+        return 0;
+    } else if (state == QContactPresence::PresenceAway) {
+        return 1;
+    } else if (state == QContactPresence::PresenceExtendedAway) {
+        return 2;
+    } else if (state == QContactPresence::PresenceBusy) {
+        return 3;
+    } else if (state == QContactPresence::PresenceHidden) {
+        return 4;
+    } else if (state == QContactPresence::PresenceOffline) {
+        return 5;
+    }
+    return 6;
+#else
+    return static_cast<int>(state);
+#endif
+}
+
 static bool betterPresence(const QContactPresence &detail, const QContactPresence &best)
 {
     if (best.isEmpty())
@@ -1818,7 +1840,8 @@ static bool betterPresence(const QContactPresence &detail, const QContactPresenc
     if (detailState == QContactPresence::PresenceUnknown)
         return false;
 
-    return (detailState < best.presenceState() || best.presenceState() == QContactPresence::PresenceUnknown);
+    return ((presenceOrder(detailState) < presenceOrder(best.presenceState())) ||
+            best.presenceState() == QContactPresence::PresenceUnknown);
 }
 
 QContactManager::Error ContactWriter::save(

--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -16,6 +16,9 @@ DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite/\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_NAME=\'\"contacts.db\"\''
 # we build a path like: /home/nemo/.local/share/system/Contacts/qtcontacts-sqlite/contacts.db
 
+# Use the option to sort presence state by availability
+DEFINES += SORT_PRESENCE_BY_AVAILABILITY
+
 INCLUDEPATH += \
         ../extensions
 


### PR DESCRIPTION
The values of presence states defined by QtContacts order Busy as
more present than Away.  However, a contact who has signalled that
they are busy is likely to be less available for communication than
one who has Away status. Add (and enable) an option to reverse the
ordering of these two states.
