### PR TITLE
[qtcontacts-sqlite] Add limited support for deleted contact change log filtering

### DIFF
--- a/src/engine/contactreader.h
+++ b/src/engine/contactreader.h
@@ -77,6 +77,10 @@ public:
             const QContactId &second);
 
 protected:
+    QContactManager::Error readDeletedContactIds(
+            QList<QContactId> *contactIds,
+            const QContactFilter &filter);
+
     QContactManager::Error queryContacts(
             const QString &table, QList<QContact> *contacts, const QContactFetchHint &fetchHint);
 


### PR DESCRIPTION
Deleted contact IDs can be retrieved via the QContactChangeLogFilter with eventType set to EventRemoved.  These filters cannot be used for general queries, or to retrieve QContact details.
