### PR TITLE
[qtcontacts-sqlite] Correct the detection of inadequate names

### DIFF
--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -2229,7 +2229,7 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
 
             // Copy some identifying detail to the local
             QContactName lcn = contact->detail<QContactName>();
-            bool copyName = (lcn.firstName().isEmpty() && lcn.lastName().isEmpty());
+            bool copyName = (!lcn.firstName().isEmpty() || !lcn.lastName().isEmpty());
             if (!copyName) {
                 // This name fails to adequately identify the contact - copy a nickname instead, if available
                 copyName = (!lcn.prefix().isEmpty() || !lcn.middleName().isEmpty() || !lcn.suffix().isEmpty());


### PR DESCRIPTION
When copying the name to an incidental local contact, the name should be used as long as it contains a first or last name element.
