### PR TITLE
[qtcontacts-sqlite] Deletions should trigger syncContactsChanged

### DIFF
--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -122,6 +122,8 @@ private:
     QContactManager::Error saveRelationships(const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap);
     QContactManager::Error removeRelationships(const QList<QContactRelationship> &relationships, QMap<int, QContactManager::Error> *errorMap);
 
+    QContactManager::Error removeContacts(const QVariantList &ids);
+
 #ifdef QTCONTACTS_SQLITE_PERFORM_AGGREGATION
     QContactManager::Error setAggregate(QContact *contact, quint32 contactId, bool update, const DetailList &definitionMask, bool withinTransaction);
     QContactManager::Error calculateDelta(QContact *contact, const ContactWriter::DetailList &definitionMask,
@@ -131,6 +133,7 @@ private:
     QContactManager::Error regenerateAggregates(const QList<quint32> &aggregateIds, const DetailList &definitionMask, bool withinTransaction);
     QContactManager::Error removeChildlessAggregates(QList<QContactId> *realRemoveIds);
     QContactManager::Error aggregateOrphanedContacts(bool withinTransaction);
+    QContactManager::Error recordAffectedSyncTargets(const QVariantList &ids);
 
     QContactManager::Error syncFetch(const QString &syncTarget, const QDateTime &lastSync, const QSet<quint32> &exportedIds,
                                      QList<QContact> *syncContacts, QList<QContact> *addedContacts, QList<QContactId> *deletedContactIds);

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -4421,6 +4421,43 @@ void tst_Aggregation::fetchSyncContacts()
     QVERIFY(contactIds.contains(flc.id()));
     QVERIFY(contactIds.contains(a3));
 
+    // Remove a local contact that affects an aggregate containing our sync target
+    QVERIFY(m_cm->removeContact(lc.id()));
+
+    // The deletion should report changes to sync targets
+    QTRY_COMPARE(syncSpy.count(), 1);
+    signalArgs = syncSpy.takeFirst();
+    QCOMPARE(syncSpy.count(), 0);
+    QCOMPARE(signalArgs.count(), 1);
+    changedSyncTargets = signalArgs.first().value<QStringList>();
+    QCOMPARE(changedSyncTargets.count(), 2);
+    QCOMPARE(changedSyncTargets.toSet(), (QSet<QString>() << "sync-test" << "different-sync-target"));
+
+    // Remove a local contact that affects a different sync target
+    QVERIFY(m_cm->removeContact(nlc.id()));
+
+    QTRY_COMPARE(syncSpy.count(), 1);
+    signalArgs = syncSpy.takeFirst();
+    QCOMPARE(syncSpy.count(), 0);
+    QCOMPARE(signalArgs.count(), 1);
+    changedSyncTargets = signalArgs.first().value<QStringList>();
+    QCOMPARE(changedSyncTargets.count(), 1);
+    QCOMPARE(changedSyncTargets.first(), QString::fromLatin1("different-sync-target"));
+
+    contactIds = m_cm->contactIds(allSyncTargets);
+    QVERIFY(contactIds.contains(stc.id()));
+    QVERIFY(!contactIds.contains(lc.id()));
+    QVERIFY(contactIds.contains(alc.id()));
+    QVERIFY(contactIds.contains(dstc.id()));
+    QVERIFY(contactIds.contains(astc.id()));
+    QVERIFY(contactIds.contains(a1));
+    QVERIFY(!contactIds.contains(nlc.id()));
+    QVERIFY(contactIds.contains(nastc.id()));
+    QVERIFY(contactIds.contains(a2));
+    QVERIFY(contactIds.contains(fstc.id()));
+    QVERIFY(contactIds.contains(flc.id()));
+    QVERIFY(contactIds.contains(a3));
+
     // Now remove all contacts
     QVERIFY(m_cm->removeContacts(QList<QContactId>() << a1 << a2 << a3));
 
@@ -4450,6 +4487,14 @@ void tst_Aggregation::fetchSyncContacts()
     QVERIFY(deletedIds.contains(stc.id()));
     QVERIFY(deletedIds.contains(astc.id()));
     QVERIFY(deletedIds.contains(nlc.id()));
+
+    QTRY_COMPARE(syncSpy.count(), 1);
+    signalArgs = syncSpy.takeFirst();
+    QCOMPARE(syncSpy.count(), 0);
+    QCOMPARE(signalArgs.count(), 1);
+    changedSyncTargets = signalArgs.first().value<QStringList>();
+    QCOMPARE(changedSyncTargets.count(), 2);
+    QCOMPARE(changedSyncTargets.toSet(), (QSet<QString>() << "sync-test" << "different-sync-target"));
 }
 
 void tst_Aggregation::storeSyncContacts()


### PR DESCRIPTION
If the deletion of a local contact causes the update of an aggregate
that aggregates a constituent from a sync target, that sync target
must be reported as modified.
