### PR TITLE
[qtcontacts-sqlite] Ensure incidental contact is linked into aggregate

### DIFF
--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -2631,7 +2631,7 @@ QContactManager::Error ContactWriter::updateLocalAndAggregate(QContact *contact,
     if (createdNewLocal) {
         // Add the aggregates relationship
         QList<QContactRelationship> saveRelationshipList;
-        saveRelationshipList.append(makeRelationship(relationshipString(QContactRelationship::Aggregates), contact->id(), writeList.at(0).id()));
+        saveRelationshipList.append(makeRelationship(relationshipString(QContactRelationship::Aggregates), contact->id(), writeList.last().id())); // the last contact will be the incidental contact, appended to the writeList above.
         writeError = save(saveRelationshipList, &errorMap, withinTransaction);
         if (writeError != QContactManager::NoError) {
             // if the aggregation relationship fails, the entire save has failed.


### PR DESCRIPTION
Previously, if a single write caused both a modify of an existing
synctarget constituent plus the creation of a new incidental contact,
the incidental contact would not be linked into the appropriate
aggregate via a relationship.
This commit ensures that the incidental contact is always linked
correctly.
