### PR TITLE
[qtcontacts-sqlite] Don't remove modified sync contacts from exportedIds

### DIFF
--- a/src/extensions/twowaycontactsyncadapter_impl.h
+++ b/src/extensions/twowaycontactsyncadapter_impl.h
@@ -797,10 +797,6 @@ QList<QPair<QContact, QContact> > TwoWayContactSyncAdapter::createUpdateList(con
             // No need to check if the change is substantial - it is, it now has a guid.
             prevRemoteModificationIndexes.insert(prmIndex, updated);
             retn.append(qMakePair(prev, updated));
-            // This sync adapter should remove that contact from the list of
-            // exported ids (as it now has a synctarget constituent, so doesn't
-            // need to be tracked separately).
-            exportedIds->removeAll(QContactId::fromString(addedModifiedGuidToGId.value(guid)));
         } else {
             // this is a pure server-side addition.
             // additions: <NULL, UPDATED_REMOTE>


### PR DESCRIPTION
Previously, any contact which was modified remotely was removed from
the exportedIds list.  This commit changes it so that the contact
is still tracked via the exportedIds list, so that if the backend
decides that the changes are incidental, and therefore the id of the
sync contact doesn't change, we continue to receive updates for it.
