### PR TITLE
[qtcontacts-sqlite] Preserve the existing ID of an exported contact

### DIFF
--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -203,7 +203,7 @@ private:
     QSqlQuery m_aggregateContactIds;
     QSqlQuery m_constituentContactDetails;
     QSqlQuery m_heuristicallyMatchData;
-    QSqlQuery m_localConstituentIds;
+    QSqlQuery m_syncTargetConstituentIds;
     QSqlQuery m_affectedSyncTargets;
     QSqlQuery m_addedSyncContactIds;
     QSqlQuery m_deletedSyncContactIds;


### PR DESCRIPTION
If a contact is exported to a sync adaptor, then a remote modification
subsequently causes it to acquire a constituent from that sync adaptor,
ensure that it continues to be exported to that sync target with the
ID of the local constituent it originated from.

This introduces the possibility of having non-local contacts marked
as incidental, which has the effect of preventing them from being used
as the base of a partial aggregate.
