### PR TITLE
[qtcontacts-sqlite] Use static cast for manager engine type cast

### DIFF
--- a/src/extensions/qtcontacts-extensions_manager_impl.h
+++ b/src/extensions/qtcontacts-extensions_manager_impl.h
@@ -43,7 +43,7 @@ namespace QtContactsSqliteExtensions {
 ContactManagerEngine *contactManagerEngine(QContactManager &manager)
 {
     if (QContactManagerData *data = QContactManagerData::managerData(&manager)) {
-        return qobject_cast<QtContactsSqliteExtensions::ContactManagerEngine *>(data->m_engine);
+        return static_cast<QtContactsSqliteExtensions::ContactManagerEngine *>(data->m_engine);
     }
 
     return 0;

--- a/src/extensions/twowaycontactsyncadapter_impl.h
+++ b/src/extensions/twowaycontactsyncadapter_impl.h
@@ -96,10 +96,9 @@ static void registerTypes()
     }
 }
 
-#define CONTACT_MANAGER_ENGINE_PTR(manager) reinterpret_cast<ContactManagerEngine*>(QContactManagerData::managerData(manager)->m_engine)
 TwoWayContactSyncAdapterPrivate::TwoWayContactSyncAdapterPrivate(const QString &syncTarget, const QMap<QString, QString> &params)
     : m_manager(new QContactManager(QStringLiteral("org.nemomobile.contacts.sqlite"), params))
-    , m_engine(CONTACT_MANAGER_ENGINE_PTR(m_manager)) // TODO: m_engine(contactManagerEngine(*m_manager))
+    , m_engine(contactManagerEngine(*m_manager))
     , m_syncTarget(syncTarget)
     , m_deleteManager(true)
 {
@@ -108,13 +107,12 @@ TwoWayContactSyncAdapterPrivate::TwoWayContactSyncAdapterPrivate(const QString &
 
 TwoWayContactSyncAdapterPrivate::TwoWayContactSyncAdapterPrivate(const QString &syncTarget, QContactManager &manager)
     : m_manager(&manager)
-    , m_engine(CONTACT_MANAGER_ENGINE_PTR(m_manager)) // TODO: m_engine(contactManagerEngine(*m_manager))
+    , m_engine(contactManagerEngine(*m_manager))
     , m_syncTarget(syncTarget)
     , m_deleteManager(false)
 {
     registerTypes();
 }
-#undef CONTACT_MANAGER_ENGINE_PTR
 
 TwoWayContactSyncAdapterPrivate::~TwoWayContactSyncAdapterPrivate()
 {

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -5497,8 +5497,7 @@ void tst_Aggregation::testOOB()
 
 void tst_Aggregation::testSyncAdapter()
 {
-    typedef QtContactsSqliteExtensions::ContactManagerEngine EngineType;
-    EngineType *cme = qobject_cast<EngineType *>(QContactManagerData::managerData(m_cm)->m_engine);
+    QtContactsSqliteExtensions::ContactManagerEngine *cme = QtContactsSqliteExtensions::contactManagerEngine(*m_cm);
 
     TestSyncAdapter tsa;
 


### PR DESCRIPTION
qobject_cast requires access to the staticMetaObject, and is not required for this conversion.
