### PR TITLE
[qtcontacts-sqlite] Supply the target aggregate for incidental contact creation

### DIFF
--- a/src/extensions/qcontactincidental.h
+++ b/src/extensions/qcontactincidental.h
@@ -40,6 +40,14 @@ class QContactIncidental : public QContactDetail
 {
 public:
     Q_DECLARE_CUSTOM_CONTACT_DETAIL(QContactIncidental)
+
+    enum {
+        FieldInitialAggregateId = 0
+    };
+
+    // This field is not available after contact creation
+    void setInitialAggregateId(const QContactId &id);
+    QContactId initialAggregateId() const;
 };
 
 QT_END_NAMESPACE_CONTACTS

--- a/src/extensions/qcontactincidental_impl.h
+++ b/src/extensions/qcontactincidental_impl.h
@@ -37,6 +37,16 @@
 
 QTCONTACTS_USE_NAMESPACE
 
+void QContactIncidental::setInitialAggregateId(const QContactId &id)
+{
+    setValue(FieldInitialAggregateId, id.toString());
+}
+
+QContactId QContactIncidental::initialAggregateId() const
+{
+    return QContactId::fromString(value<QString>(FieldInitialAggregateId));
+}
+
 const QContactDetail::DetailType QContactIncidental::Type(static_cast<QContactDetail::DetailType>(QContactDetail__TypeIncidental));
 
 #endif

--- a/src/extensions/qtcontacts-extensions.h
+++ b/src/extensions/qtcontacts-extensions.h
@@ -76,6 +76,7 @@ static const QContactDetail::DetailType QContactDetail__TypeStatusFlags = static
 // We support the QContactDeactivated detail type
 static const QContactDetail::DetailType QContactDetail__TypeDeactivated = static_cast<QContactDetail::DetailType>(QContactDetail::TypeVersion + 3);
 
+// Incidental is an internal property of a contact relating to the contact's inception
 static const QContactDetail::DetailType QContactDetail__TypeIncidental = static_cast<QContactDetail::DetailType>(QContactDetail::TypeVersion + 4);
 
 QT_END_NAMESPACE_CONTACTS

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -1298,11 +1298,11 @@ void tst_Aggregation::promotionToSingleLocal()
     setFilterDetail<QContactSyncTarget>(allSyncTargets, QContactSyncTarget::FieldSyncTarget);
 
     // first, save a sync target alice.  This should generate an aggregate, but not a local.
+    // (with no last name, we require QContactIncidental to find the correct aggregate)
     QContact syncAlice;
     QContactName san;
     san.setFirstName(QLatin1String("Single"));
     san.setMiddleName(QLatin1String("Promotion"));
-    san.setLastName(QLatin1String("ToAggregate"));
     syncAlice.saveDetail(&san);
 
     QContactEmailAddress saem;
@@ -1327,7 +1327,7 @@ void tst_Aggregation::promotionToSingleLocal()
         QContactName currName = curr.detail<QContactName>();
         if (currName.firstName() == QLatin1String("Single")
                 && currName.middleName() == QLatin1String("Promotion")
-                && currName.lastName() == QLatin1String("ToAggregate")
+                && currName.lastName().isEmpty()
                 && currEm.emailAddress() == QLatin1String("spta@test.com")) {
             if (currSt.syncTarget() == QLatin1String("test")) {
                 syncAlice = curr;
@@ -1370,7 +1370,7 @@ void tst_Aggregation::promotionToSingleLocal()
         QContactFavorite currFav = curr.detail<QContactFavorite>();
         if (currName.firstName() == QLatin1String("Single")
                 && currName.middleName() == QLatin1String("Promotion")
-                && currName.lastName() == QLatin1String("ToAggregate")) {
+                && currName.lastName().isEmpty()) {
             if (currSt.syncTarget() == QLatin1String("test")) {
                 QVERIFY(!foundSyncAlice); // found more than one = error...
                 QCOMPARE(currEm.emailAddress(), QLatin1String("spta@test.com"));
@@ -1430,7 +1430,7 @@ void tst_Aggregation::promotionToSingleLocal()
         QContactName currName = curr.detail<QContactName>();
         if (currName.firstName() == QLatin1String("Single")
                 && currName.middleName() == QLatin1String("Promotion")
-                && currName.lastName() == QLatin1String("ToAggregate")) {
+                && currName.lastName().isEmpty()) {
             if (currSt.syncTarget() == QLatin1String("test")) {
                 QVERIFY(!foundSyncAlice); // found more than one = error...
                 syncAlice = curr;
@@ -1492,7 +1492,7 @@ void tst_Aggregation::promotionToSingleLocal()
         QContactName currName = curr.detail<QContactName>();
         if (currName.firstName() == QLatin1String("Single")
                 && currName.middleName() == QLatin1String("Promotion")
-                && currName.lastName() == QLatin1String("ToAggregate")) {
+                && currName.lastName().isEmpty()) {
             if (currSt.syncTarget() == QLatin1String("test")) {
                 QVERIFY(!foundSyncAlice); // found more than one = error...
                 syncAlice = curr;


### PR DESCRIPTION
When we create an incidental contact to store data for an existing contact, the ID of the aggregate for the new contact is already known.  Supply this information to the save function, so that we do not need to perform a search for the appropriate aggregate.
