### PR TITLE
[qtcontacts-sqlite] Relax permissions on created semaphores

### DIFF
--- a/src/engine/semaphore_p.cpp
+++ b/src/engine/semaphore_p.cpp
@@ -69,7 +69,7 @@ int semaphoreInit(const char *id, size_t count, const int *initialValues)
             semaphoreError("Unable to get semaphore", id, errno);
         } else {
             // The semaphore does not currently exist
-            rv = ::semget(key, count, IPC_CREAT | IPC_EXCL | S_IRWXU);
+            rv = ::semget(key, count, IPC_CREAT | IPC_EXCL | S_IRWXO | S_IRWXG | S_IRWXU);
             if (rv == -1) {
                 if (errno == EEXIST) {
                     // Someone else won the race to create the semaphore - retry get 


### PR DESCRIPTION
Previously, only the uid of the process which first created the
semaphore could commit changes to the database.  This commit ensures
that any uid can do so, by relaxing the mode specified when creating
the semaphore.

Note that access to the database itself is still restricted according
to the filesystem permissions.
