### PR TITLE
[qtcontacts-sqlite] Allow suppression of sync contacts change signal

### DIFF
--- a/src/engine/contactwriter.h
+++ b/src/engine/contactwriter.h
@@ -112,7 +112,7 @@ public:
 
 private:
     bool beginTransaction();
-    bool commitTransaction();
+    bool commitTransaction(const QStringList &suppressSyncTargets = QStringList());
     void rollbackTransaction();
 
     QContactManager::Error create(QContact *contact, const DetailList &definitionMask, bool withinTransaction, bool withinAggregateUpdate);


### PR DESCRIPTION
This commit ensures that the syncContactsChanged signal is not emitted
for the sync target of the sync adapter which causes the change.
That signal exists to tell the sync adapter that it may need to
perform a sync due to a change on the local device; if the change was
caused by that sync adapter, then we don't need to tell it about the
change, obviously.

This helps prevent sync triggering cycles.
