### PR TITLE
[qtcontacts-sqlite] Allow filtering/sorting on transient update timestamp

### DIFF
--- a/src/engine/contactsdatabase.h
+++ b/src/engine/contactsdatabase.h
@@ -129,18 +129,15 @@ public:
     bool createTransientContactIdsTable(const QString &table, const QVariantList &ids, QString *transientTableName);
     void clearTransientContactIdsTable(const QString &table);
 
-    bool createTemporaryContactPresenceTable(const QString &table, const QList<QPair<quint32, qint64> > &values);
-    void clearTemporaryContactPresenceTable(const QString &table);
-
-    bool populateTemporaryGlobalPresenceStates();
+    bool populateTemporaryTransientState(bool timestamps, bool globalPresence);
 
     Query prepare(const char *statement);
     Query prepare(const QString &statement);
 
     bool hasTransientDetails(quint32 contactId);
 
-    QList<QContactDetail> transientDetails(quint32 contactId) const;
-    bool setTransientDetails(quint32 contactId, const QList<QContactDetail> &details);
+    QPair<QDateTime, QList<QContactDetail> > transientDetails(quint32 contactId) const;
+    bool setTransientDetails(quint32 contactId, const QDateTime &timestamp, const QList<QContactDetail> &details);
 
     bool removeTransientDetails(quint32 contactId);
     bool removeTransientDetails(const QList<quint32> &contactIds);
@@ -148,6 +145,13 @@ public:
     static QString expandQuery(const QString &queryString, const QVariantList &bindings);
     static QString expandQuery(const QString &queryString, const QMap<QString, QVariant> &bindings);
     static QString expandQuery(const QSqlQuery &query);
+
+    // Input must be UTC
+    static QString dateTimeString(const QDateTime &qdt);
+    static QString dateString(const QDateTime &qdt);
+
+    // Output is UTC
+    static QDateTime fromDateTimeString(const QString &s);
 
 private:
     QSqlDatabase m_database;

--- a/src/engine/contactstransientstore.h
+++ b/src/engine/contactstransientstore.h
@@ -38,6 +38,9 @@
 
 #include <QContactDetail>
 
+#include <QDateTime>
+#include <QPair>
+
 QTCONTACTS_USE_NAMESPACE
 
 class ContactsTransientStore
@@ -55,7 +58,7 @@ public:
         const_iterator &operator=(const const_iterator &other);
 
         quint32 key();
-        QList<QContactDetail> value();
+        QPair<QDateTime, QList<QContactDetail> > value();
     };
 
     ContactsTransientStore();
@@ -65,8 +68,8 @@ public:
 
     bool contains(quint32 contactId) const;
 
-    QList<QContactDetail> contactDetails(quint32 contactId) const;
-    bool setContactDetails(quint32 contactId, const QList<QContactDetail> &details);
+    QPair<QDateTime, QList<QContactDetail> > contactDetails(quint32 contactId) const;
+    bool setContactDetails(quint32 contactId, const QDateTime &timestamp, const QList<QContactDetail> &details);
 
     bool remove(quint32 contactId);
     bool remove(const QList<quint32> &contactId);


### PR DESCRIPTION
When a contact's transient details are updated, the timestamp is not
modified; we must also consult the timestamp of the transient data
when performing change log filtering.
