### PR TITLE
[qtcontacts-sqlite] Ignore results when transient data is inaccessible

### DIFF
--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -1884,6 +1884,8 @@ bool ContactsDatabase::populateTemporaryTransientState(bool timestamps, bool glo
     ContactsTransientStore::const_iterator it = m_transientStore.constBegin(), end = m_transientStore.constEnd();
     for ( ; it != end; ++it) {
         QPair<QDateTime, QList<QContactDetail> > details(it.value());
+        if (details.first.isNull())
+            continue;
 
         if (timestamps) {
             timestampValues.append(qMakePair<quint32, QString>(it.key(), dateTimeString(details.first)));

--- a/src/engine/memorytable.cpp
+++ b/src/engine/memorytable.cpp
@@ -564,11 +564,17 @@ bool MemoryTable::const_iterator::operator!=(const const_iterator &other)
 
 MemoryTable::key_type MemoryTable::const_iterator::key()
 {
+    if (!table)
+        return MemoryTable::key_type();
+
     return table->keyAt(position);
 }
 
 MemoryTable::value_type MemoryTable::const_iterator::value()
 {
+    if (!table)
+        return MemoryTable::value_type();
+
     return table->valueAt(position);
 }
 


### PR DESCRIPTION
Transient reads are permitted to fail without aborting; if so, do not
use the data returned from the failed read.
