### PR TITLE
[qtcontacts-sqlite] Ensure all detail table queries are finished

### DIFF
--- a/src/engine/contactreader.h
+++ b/src/engine/contactreader.h
@@ -94,6 +94,8 @@ protected:
 
     QContactManager::Error queryContacts(
             const QString &table, QList<QContact> *contacts, const QContactFetchHint &fetchHint, bool relaxConstraints = false);
+    QContactManager::Error queryContacts(
+            const QString &table, QList<QContact> *contacts, const QContactFetchHint &fetchHint, bool relaxConstraints, QSqlQuery &query, QList<QSqlQuery> *activeQueries);
 
     virtual void contactsAvailable(const QList<QContact> &contacts);
     virtual void contactIdsAvailable(const QList<QContactId> &contactIds);


### PR DESCRIPTION
If we fail to prepare a details table query, return an error and
ensure that any queries that were activated are finalized.
