### PR TITLE
[qtcontacts-sqlite] Make DetailsJoinIndex unique to optimize queries

### DIFF
--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -248,7 +248,7 @@ static const char *createDetailsTable =
         "\n nonexportable BOOL);";
 
 static const char *createDetailsJoinIndex =
-        "\n CREATE INDEX DetailsJoinIndex ON Details(detailId, detail);";
+        "\n CREATE UNIQUE INDEX DetailsJoinIndex ON Details(detailId, detail);";
 
 static const char *createDetailsRemoveIndex =
         "\n CREATE INDEX DetailsRemoveIndex ON Details(contactId, detail);";
@@ -637,6 +637,12 @@ static const char *upgradeVersion8[] = {
     "PRAGMA user_version=9",
     0 // NULL-terminated
 };
+static const char *upgradeVersion9[] = {
+    "DROP INDEX DetailsJoinIndex",
+    createDetailsJoinIndex,
+    "PRAGMA user_version=10",
+    0 // NULL-terminated
+};
 
 typedef bool (*UpgradeFunction)(QSqlDatabase &database);
 
@@ -711,9 +717,10 @@ static UpgradeOperation upgradeVersions[] = {
     { 0,                        upgradeVersion6 },
     { updateNormalizedNumbers,  upgradeVersion7 },
     { 0,                        upgradeVersion8 },
+    { 0,                        upgradeVersion9 },
 };
 
-static const int currentSchemaVersion = 9;
+static const int currentSchemaVersion = 10;
 
 static bool execute(QSqlDatabase &database, const QString &statement)
 {


### PR DESCRIPTION
SQLite 3.8.5's query planner weighs the detail queries differently, and
(somewhat inexplicably) decides to create an automatic index similar to
DetailsJoinIndex rather than using it. That slows down many queries by
15-20ms, leading to delays of multiple minutes in some cases.

We should look into analyzing the indexes properly, but the best way to
optimize this query now is to make Details(detailId, detail) a unique
index.

If there are concerns with the uniqueness of existing data for these
fields, we can work around the problem using INDEXED BY in the affected
queries.
