### PR TITLE
[qtcontacts-sqlite] Remove detail URI unique constraint

### DIFF
--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -261,7 +261,7 @@ static const char *createDetailsTable =
         "\n detailId INTEGER PRIMARY KEY ASC AUTOINCREMENT,"
         "\n contactId INTEGER REFERENCES Contacts (contactId),"
         "\n detail TEXT,"
-        "\n detailUri TEXT UNIQUE,"
+        "\n detailUri TEXT,"
         "\n linkedDetailUris TEXT,"
         "\n contexts TEXT,"
         "\n accessConstraints INTEGER,"
@@ -1175,6 +1175,37 @@ static const char *upgradeVersion11[] = {
     "PRAGMA user_version=12",
     0 // NULL-terminated
 };
+static const char *upgradeVersion12[] = {
+    // Preserve the existing state of the Details table
+    "ALTER TABLE Details RENAME TO OldDetails",
+    createDetailsTable,
+    "INSERT INTO Details("
+        "detailId,"
+        "contactId,"
+        "detail,"
+        "detailUri,"
+        "linkedDetailUris,"
+        "contexts,"
+        "accessConstraints,"
+        "provenance,"
+        "modifiable,"
+        "nonexportable)"
+    "SELECT "
+        "detailId,"
+        "contactId,"
+        "detail,"
+        "detailUri,"
+        "linkedDetailUris,"
+        "contexts,"
+        "accessConstraints,"
+        "provenance,"
+        "modifiable,"
+        "nonexportable "
+    "FROM OldDetails",
+    "DROP TABLE OldDetails",
+    "PRAGMA user_version=13",
+    0 // NULL-terminated
+};
 
 typedef bool (*UpgradeFunction)(QSqlDatabase &database);
 
@@ -1252,9 +1283,10 @@ static UpgradeOperation upgradeVersions[] = {
     { 0,                        upgradeVersion9 },
     { 0,                        upgradeVersion10 },
     { 0,                        upgradeVersion11 },
+    { 0,                        upgradeVersion12 },
 };
 
-static const int currentSchemaVersion = 12;
+static const int currentSchemaVersion = 13;
 
 static bool execute(QSqlDatabase &database, const QString &statement)
 {

--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -2537,6 +2537,8 @@ static QContactManager::Error enforceDetailConstraints(QContact *contact)
 
     QHash<ContactWriter::DetailList::value_type, int> detailCounts;
 
+    QSet<QString> detailUris;
+
     // look for unsupported detail data.
     foreach (const QContactDetail &det, contact->details()) {
         if (!detailListContains(supported, det)) {
@@ -2544,6 +2546,18 @@ static QContactManager::Error enforceDetailConstraints(QContact *contact)
             return QContactManager::InvalidDetailError;
         } else {
             ++detailCounts[detailType(det)];
+
+            // Verify that detail URIs are unique within the contact
+            const QString detailUri(det.detailUri());
+            if (!detailUri.isEmpty()) {
+                if (detailUris.contains(detailUri)) {
+                    // This URI conflicts with one already present in the contact
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Detail URI confict on: %1 %2 %3").arg(detailUri).arg(detailTypeName(det)).arg(det.type()));
+                    return QContactManager::InvalidDetailError;
+                }
+
+                detailUris.insert(detailUri);
+            }
         }
     }
 


### PR DESCRIPTION
The uniqueness constraint on detail URI should be applied only within a single contact, not across the set of all details.
