### PR TITLE
[qtcontacts-sqlite] handle non-numeric phone numbers in reader

### DIFF
--- a/src/engine/contactreader.cpp
+++ b/src/engine/contactreader.cpp
@@ -984,6 +984,11 @@ static QString buildWhere(const QContactDetailFilter &filter, QVariantList *bind
             if (useNormalizedNumber) {
                 // Normalize the input for comparison
                 bindValue = ContactsEngine::normalizedPhoneNumber(stringValue);
+                if (bindValue.isEmpty()) {
+                    *failed = true;
+                    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Failed with invalid phone number: %1").arg(stringValue));
+                    return QLatin1String("FAILED");
+                }
                 if (caseInsensitive) {
                     bindValue = bindValue.toLower();
                 }


### PR DESCRIPTION
When a "phone number" normalizes to an empty string, match the un-normalized string instead.

Before this fix, non-numeric phone numbers were all normalized to empty strings and would all match each other.
