### PR TITLE
[qtcontacts-sqlite] Make the asynchronous DB connection primary

### DIFF
--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -2297,6 +2297,11 @@ QSqlError ContactsDatabase::lastError() const
     return m_database.lastError();
 }
 
+bool ContactsDatabase::isOpen() const
+{
+    return m_database.isOpen();
+}
+
 bool ContactsDatabase::nonprivileged() const
 {
     return m_nonprivileged;

--- a/src/engine/contactsdatabase.cpp
+++ b/src/engine/contactsdatabase.cpp
@@ -2182,9 +2182,8 @@ bool ContactsDatabase::open(const QString &connectionName, bool nonprivileged, b
         return false;
     }
 
-    // horrible hack: Qt4 didn't have GenericDataLocation so we hardcode DATA_DIR location.
-    const QString unprivilegedDataDirPath(QString::fromLatin1(QTCONTACTS_SQLITE_CENTRAL_DATA_DIR) + "/");
-    const QString privilegedDataDirPath(unprivilegedDataDirPath + QTCONTACTS_SQLITE_PRIVILEGED_DIR + "/");
+    const QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/system/");
+    const QString privilegedDataDirPath(systemDataDirPath + QTCONTACTS_SQLITE_PRIVILEGED_DIR + "/");
 
     QString databaseSubdir(QString::fromLatin1(QTCONTACTS_SQLITE_DATABASE_DIR));
     if (autoTest) {
@@ -2197,11 +2196,11 @@ bool ContactsDatabase::open(const QString &connectionName, bool nonprivileged, b
         databaseDir = privilegedDataDirPath + databaseSubdir;
     } else {
         // not privileged.
-        if (!databaseDir.mkpath(unprivilegedDataDirPath + databaseSubdir)) {
-            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to create contacts database directory: %1").arg(unprivilegedDataDirPath + databaseSubdir));
+        if (!databaseDir.mkpath(systemDataDirPath + databaseSubdir)) {
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to create contacts database directory: %1").arg(systemDataDirPath + databaseSubdir));
             return false;
         }
-        databaseDir = unprivilegedDataDirPath + databaseSubdir;
+        databaseDir = systemDataDirPath + databaseSubdir;
         if (!nonprivileged) {
             QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Could not access privileged data directory; using nonprivileged"));
         }

--- a/src/engine/contactsdatabase.h
+++ b/src/engine/contactsdatabase.h
@@ -114,6 +114,7 @@ public:
 
     QSqlError lastError() const;
 
+    bool isOpen() const;
     bool nonprivileged() const;
     bool aggregating() const;
     bool localized() const;

--- a/src/engine/contactsdatabase.h
+++ b/src/engine/contactsdatabase.h
@@ -107,7 +107,7 @@ public:
     QMutex *accessMutex() const;
     ProcessMutex *processMutex() const;
 
-    bool open(const QString &databaseName, bool nonprivileged, bool secondaryConnection = false);
+    bool open(const QString &databaseName, bool nonprivileged, bool autoTest, bool secondaryConnection = false);
 
     operator QSqlDatabase &();
     operator QSqlDatabase const &() const;

--- a/src/engine/contactsengine.cpp
+++ b/src/engine/contactsengine.cpp
@@ -502,9 +502,9 @@ public:
     JobThread(ContactsEngine *engine, const QString &databaseUuid, bool nonprivileged, bool autoTest)
         : m_currentJob(0)
         , m_engine(engine)
-        , m_updatePending(false)
-        , m_running(true)
         , m_databaseUuid(databaseUuid)
+        , m_updatePending(false)
+        , m_running(false)
         , m_nonprivileged(nonprivileged)
         , m_autoTest(autoTest)
     {
@@ -516,12 +516,26 @@ public:
         {
             QMutexLocker locker(&m_mutex);
             m_running = false;
-            m_wait.wakeOne();
         }
+        m_wait.wakeOne();
         wait();
     }
 
     void run();
+
+    bool waitForRunning()
+    {
+        QMutexLocker locker(&m_mutex);
+        if (!m_running) {
+            m_wait.wait(&m_mutex);
+        }
+        return m_database.isOpen();
+    }
+
+    bool nonprivileged() const
+    {
+        return m_nonprivileged;
+    }
 
     void enqueue(Job *job)
     {
@@ -707,9 +721,10 @@ private:
     QList<Job*> m_cancelledJobs;
     Job *m_currentJob;
     ContactsEngine *m_engine;
+    ContactsDatabase m_database;
+    QString m_databaseUuid;
     bool m_updatePending;
     bool m_running;
-    QString m_databaseUuid;
     bool m_nonprivileged;
     bool m_autoTest;
 };
@@ -742,8 +757,17 @@ void JobThread::run()
     QString dbId(QStringLiteral("qtcontacts-sqlite%1-job-%2"));
     dbId = dbId.arg(m_autoTest ? QStringLiteral("-test") : QString()).arg(m_databaseUuid);
 
-    ContactsDatabase database;
-    if (!database.open(dbId, m_nonprivileged, m_autoTest, true)) {
+    QMutexLocker locker(&m_mutex);
+
+    m_database.open(dbId, m_nonprivileged, m_autoTest);
+    m_nonprivileged = m_database.nonprivileged();
+    m_running = true;
+
+    locker.unlock();
+    m_wait.wakeOne();
+    locker.relock();
+
+    if (!m_database.isOpen()) {
         while (m_running) {
             if (m_pendingJobs.isEmpty()) {
                 m_wait.wait(&m_mutex);
@@ -756,35 +780,31 @@ void JobThread::run()
                 m_finishedWait.wakeOne();
             }
         }
+    } else {
+        ContactNotifier notifier(m_nonprivileged);
+        JobContactReader reader(m_database, this);
+        Job::WriterProxy writer(*m_engine, m_database, notifier, reader);
 
-        return;
-    }
+        while (m_running) {
+            if (m_pendingJobs.isEmpty()) {
+                m_wait.wait(&m_mutex);
+            } else {
+                m_currentJob = m_pendingJobs.takeFirst();
+                locker.unlock();
 
-    ContactNotifier notifier(database.nonprivileged());
-    JobContactReader reader(database, this);
-    Job::WriterProxy writer(*m_engine, database, notifier, reader);
+                QElapsedTimer timer;
+                timer.start();
 
-    QMutexLocker locker(&m_mutex);
+                m_currentJob->execute(&reader, writer);
+                QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Job executed in %1 ms : %2 : error = %3")
+                        .arg(timer.elapsed()).arg(m_currentJob->description()).arg(m_currentJob->error()));
 
-    while (m_running) {
-        if (m_pendingJobs.isEmpty()) {
-            m_wait.wait(&m_mutex);
-        } else {
-            m_currentJob = m_pendingJobs.takeFirst();
-            locker.unlock();
-
-            QElapsedTimer timer;
-            timer.start();
-
-            m_currentJob->execute(&reader, writer);
-            QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Job executed in %1 ms : %2 : error = %3")
-                    .arg(timer.elapsed()).arg(m_currentJob->description()).arg(m_currentJob->error()));
-
-            locker.relock();
-            m_finishedJobs.append(m_currentJob);
-            m_currentJob = 0;
-            postUpdate();
-            m_finishedWait.wakeOne();
+                locker.relock();
+                m_finishedJobs.append(m_currentJob);
+                m_currentJob = 0;
+                postUpdate();
+                m_finishedWait.wakeOne();
+            }
         }
     }
 }
@@ -833,26 +853,30 @@ QString ContactsEngine::databaseUuid()
 
 QContactManager::Error ContactsEngine::open()
 {
-    QString dbId(QStringLiteral("qtcontacts-sqlite%1-%2"));
-    dbId = dbId.arg(m_autoTest ? QStringLiteral("-test") : QString()).arg(databaseUuid());
+    // Start the async thread, and wait to see if it can open the database
+    if (!m_jobThread)
+        m_jobThread.reset(new JobThread(this, databaseUuid(), m_nonprivileged, m_autoTest));
 
-    if (m_database.open(dbId, m_nonprivileged, m_autoTest)) {
-        setNonprivileged(m_database.nonprivileged());
+    if (m_jobThread->waitForRunning()) {
+        // We may not have got privileged access if we requested it
+        setNonprivileged(m_jobThread->nonprivileged());
 
-        m_notifier.reset(new ContactNotifier(m_nonprivileged));
-        m_notifier->connect("contactsAdded", "au", this, SLOT(_q_contactsAdded(QVector<quint32>)));
-        m_notifier->connect("contactsChanged", "au", this, SLOT(_q_contactsChanged(QVector<quint32>)));
-        m_notifier->connect("contactsPresenceChanged", "au", this, SLOT(_q_contactsPresenceChanged(QVector<quint32>)));
-        m_notifier->connect("syncContactsChanged", "as", this, SLOT(_q_syncContactsChanged(QStringList)));
-        m_notifier->connect("contactsRemoved", "au", this, SLOT(_q_contactsRemoved(QVector<quint32>)));
-        m_notifier->connect("selfContactIdChanged", "uu", this, SLOT(_q_selfContactIdChanged(quint32,quint32)));
-        m_notifier->connect("relationshipsAdded", "au", this, SLOT(_q_relationshipsAdded(QVector<quint32>)));
-        m_notifier->connect("relationshipsRemoved", "au", this, SLOT(_q_relationshipsRemoved(QVector<quint32>)));
+        if (!m_notifier) {
+            m_notifier.reset(new ContactNotifier(m_nonprivileged));
+            m_notifier->connect("contactsAdded", "au", this, SLOT(_q_contactsAdded(QVector<quint32>)));
+            m_notifier->connect("contactsChanged", "au", this, SLOT(_q_contactsChanged(QVector<quint32>)));
+            m_notifier->connect("contactsPresenceChanged", "au", this, SLOT(_q_contactsPresenceChanged(QVector<quint32>)));
+            m_notifier->connect("syncContactsChanged", "as", this, SLOT(_q_syncContactsChanged(QStringList)));
+            m_notifier->connect("contactsRemoved", "au", this, SLOT(_q_contactsRemoved(QVector<quint32>)));
+            m_notifier->connect("selfContactIdChanged", "uu", this, SLOT(_q_selfContactIdChanged(quint32,quint32)));
+            m_notifier->connect("relationshipsAdded", "au", this, SLOT(_q_relationshipsAdded(QVector<quint32>)));
+            m_notifier->connect("relationshipsRemoved", "au", this, SLOT(_q_relationshipsRemoved(QVector<quint32>)));
+        }
         return QContactManager::NoError;
-    } else {
-        QTCONTACTS_SQLITE_WARNING((QString::fromLatin1("Unable to open engine database %1"), dbId));
-        return QContactManager::UnspecifiedError;
     }
+
+    QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to open asynchronous engine database connection"));
+    return QContactManager::UnspecifiedError;
 }
 
 QString ContactsEngine::managerName() const
@@ -1090,8 +1114,6 @@ bool ContactsEngine::startRequest(QContactAbstractRequest* request)
         return false;
     }
 
-    if (!m_jobThread)
-        m_jobThread.reset(new JobThread(this, databaseUuid(), m_nonprivileged, m_autoTest));
     job->updateState(QContactAbstractRequest::ActiveState);
     m_jobThread->enqueue(job);
 
@@ -1362,10 +1384,24 @@ void ContactsEngine::_q_relationshipsRemoved(const QVector<quint32> &contactIds)
     emit relationshipsRemoved(idList(contactIds));
 }
 
+ContactsDatabase &ContactsEngine::database()
+{
+    if (!m_database) {
+        QString dbId(QStringLiteral("qtcontacts-sqlite%1-%2"));
+        dbId = dbId.arg(m_autoTest ? QStringLiteral("-test") : QString()).arg(databaseUuid());
+
+        m_database.reset(new ContactsDatabase);
+        if (!m_database->open(dbId, m_nonprivileged, m_autoTest, true)) {
+            QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Unable to open synchronous engine database connection"));
+        }
+    }
+    return *m_database;
+}
+
 ContactReader *ContactsEngine::reader() const
 {
     if (!m_synchronousReader) {
-        m_synchronousReader.reset(new ContactReader(const_cast<ContactsDatabase &>(m_database)));
+        m_synchronousReader.reset(new ContactReader(const_cast<ContactsEngine *>(this)->database()));
     }
     return m_synchronousReader.data();
 }
@@ -1373,7 +1409,7 @@ ContactReader *ContactsEngine::reader() const
 ContactWriter *ContactsEngine::writer()
 {
     if (!m_synchronousWriter) {
-        m_synchronousWriter.reset(new ContactWriter(*this, m_database, m_notifier.data(), reader()));
+        m_synchronousWriter.reset(new ContactWriter(*this, database(), m_notifier.data(), reader()));
     }
     return m_synchronousWriter.data();
 }

--- a/src/engine/contactsengine.h
+++ b/src/engine/contactsengine.h
@@ -177,6 +177,7 @@ private slots:
 
 private:
     QString databaseUuid();
+    ContactsDatabase &database();
 
     ContactReader *reader() const;
     ContactWriter *writer();
@@ -184,7 +185,7 @@ private:
     QString m_databaseUuid;
     const QString m_name;
     QMap<QString, QString> m_parameters;
-    ContactsDatabase m_database;
+    QScopedPointer<ContactsDatabase> m_database;
     mutable QScopedPointer<ContactReader> m_synchronousReader;
     QScopedPointer<ContactWriter> m_synchronousWriter;
     QScopedPointer<ContactNotifier> m_notifier;

--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -9,7 +9,6 @@ CONFIG += plugin hide_symbols
 PLUGIN_TYPE=contacts
 
 # we hardcode this for Qt4 as there's no GenericDataLocation offered by QDesktopServices
-DEFINES += 'QTCONTACTS_SQLITE_CENTRAL_DATA_DIR=\'\"/home/nemo/.local/share/system\"\''
 DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DIR=\'\"privileged\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_NAME=\'\"contacts.db\"\''

--- a/src/engine/engine.pro
+++ b/src/engine/engine.pro
@@ -9,9 +9,9 @@ CONFIG += plugin hide_symbols
 PLUGIN_TYPE=contacts
 
 # we hardcode this for Qt4 as there's no GenericDataLocation offered by QDesktopServices
-DEFINES += 'QTCONTACTS_SQLITE_CENTRAL_DATA_DIR=\'\"/home/nemo/.local/share/system/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_CENTRAL_DATA_DIR=\'\"/home/nemo/.local/share/system\"\''
 DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DIR=\'\"privileged\"\''
-DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_NAME=\'\"contacts.db\"\''
 # we build a path like: /home/nemo/.local/share/system/Contacts/qtcontacts-sqlite/contacts.db
 

--- a/src/extensions/contactmanagerengine.h
+++ b/src/extensions/contactmanagerengine.h
@@ -44,9 +44,11 @@ namespace QtContactsSqliteExtensions {
  *                           and reported via the contactsChanged signal. Otherwise presence
  *                           changes will be reported separately, via the contactsPresenceChanged
  *                           signal of the QContactManager's engine object.
- * 'nonprivileged'         - if true, the engine will not attempt to use the privileged database
+ *  'nonprivileged'        - if true, the engine will not attempt to use the privileged database
  *                           of contact details, which is not accessible to normal processes. Otherwise
  *                           the privileged database will be preferred if accessible.
+ *  'autoTest'             - if true, an alternate database path is accessed, separate to the
+ *                           path used by non-auto-test applications
  */
 
 class Q_DECL_EXPORT ContactManagerEngine
@@ -60,10 +62,11 @@ public:
         PreserveRemoteChanges
     };
 
-    ContactManagerEngine() : m_nonprivileged(false), m_mergePresenceChanges(false) {}
+    ContactManagerEngine() : m_nonprivileged(false), m_mergePresenceChanges(false), m_autoTest(false) {}
 
     void setNonprivileged(bool b) { m_nonprivileged = b; }
     void setMergePresenceChanges(bool b) { m_mergePresenceChanges = b; }
+    void setAutoTest(bool b) { m_autoTest = b; }
 
     virtual bool Q_DECL_DEPRECATED fetchSyncContacts(const QString &syncTarget, const QDateTime &lastSync, const QList<QContactId> &exportedIds,
                                    QList<QContact> *syncContacts, QList<QContact> *addedContacts, QList<QContactId> *deletedContactIds,
@@ -97,6 +100,7 @@ Q_SIGNALS:
 protected:
     bool m_nonprivileged;
     bool m_mergePresenceChanges;
+    bool m_autoTest;
 };
 
 }

--- a/tests/auto/aggregation/testsyncadapter.cpp
+++ b/tests/auto/aggregation/testsyncadapter.cpp
@@ -42,8 +42,19 @@
 
 #define TSA_GUID_STRING(accountId, fname, lname) QString(accountId + ":" + fname + lname)
 
+namespace {
+
+QMap<QString, QString> managerParameters() {
+    QMap<QString, QString> params;
+    params.insert(QStringLiteral("autoTest"), QStringLiteral("true"));
+    params.insert(QStringLiteral("mergePresenceChanges"), QStringLiteral("true"));
+    return params;
+}
+
+}
+
 TestSyncAdapter::TestSyncAdapter(QObject *parent)
-    : QObject(parent), TwoWayContactSyncAdapter(QStringLiteral("testsyncadapter"))
+    : QObject(parent), TwoWayContactSyncAdapter(QStringLiteral("testsyncadapter"), managerParameters())
 {
 }
 

--- a/tests/auto/aggregation/testsyncadapter.h
+++ b/tests/auto/aggregation/testsyncadapter.h
@@ -89,8 +89,6 @@ private Q_SLOTS:
     void finalizeTwoWaySync();
 
 private:
-    QContactManager m_manager;
-
     // simulating server-side changes, per account:
     mutable QMap<QString, QTimer*> m_simulationTimers;
     mutable QMap<QString, bool> m_downsyncWasRequired;

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -136,6 +136,7 @@ tst_Aggregation::tst_Aggregation()
     : m_cm(0)
 {
     QMap<QString, QString> parameters;
+    parameters.insert(QString::fromLatin1("autoTest"), QString::fromLatin1("true"));
     parameters.insert(QString::fromLatin1("mergePresenceChanges"), QString::fromLatin1("true"));
     m_cm = new QContactManager(QString::fromLatin1("org.nemomobile.contacts.sqlite"), parameters);
 

--- a/tests/auto/database/database.pro
+++ b/tests/auto/database/database.pro
@@ -5,7 +5,6 @@ TARGET = tst_database
 QT += sql contacts-private
 
 # copied from src/engine/engine.pro, modified for test db
-DEFINES += 'QTCONTACTS_SQLITE_CENTRAL_DATA_DIR=\'\"/home/nemo/.local/share/system\"\''
 DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DIR=\'\"privileged\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_NAME=\'\"contacts-test.db\"\''

--- a/tests/auto/database/database.pro
+++ b/tests/auto/database/database.pro
@@ -5,11 +5,11 @@ TARGET = tst_database
 QT += sql contacts-private
 
 # copied from src/engine/engine.pro, modified for test db
-DEFINES += 'QTCONTACTS_SQLITE_CENTRAL_DATA_DIR=\'\"/home/nemo/.local/share/system/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_CENTRAL_DATA_DIR=\'\"/home/nemo/.local/share/system\"\''
 DEFINES += 'QTCONTACTS_SQLITE_PRIVILEGED_DIR=\'\"privileged\"\''
-DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite/\"\''
+DEFINES += 'QTCONTACTS_SQLITE_DATABASE_DIR=\'\"Contacts/qtcontacts-sqlite\"\''
 DEFINES += 'QTCONTACTS_SQLITE_DATABASE_NAME=\'\"contacts-test.db\"\''
-# we build a path like: /home/nemo/.local/share/system/Contacts/qtcontacts-sqlite/contacts-test.db
+# we build a path like: /home/nemo/.local/share/system/Contacts/qtcontacts-sqlite-test/contacts-test.db
 
 INCLUDEPATH += \
     ../../../src/engine/

--- a/tests/auto/phonenumber/tst_phonenumber.cpp
+++ b/tests/auto/phonenumber/tst_phonenumber.cpp
@@ -35,8 +35,6 @@
 #include "../../../src/extensions/qtcontacts-extensions.h"
 #include "../../../src/extensions/qtcontacts-extensions_impl.h"
 
-#define SQLITE_MANAGER "org.nemomobile.contacts.sqlite"
-
 class tst_PhoneNumber : public QObject
 {
 Q_OBJECT

--- a/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
+++ b/tests/auto/qcontactmanager/tst_qcontactmanager.cpp
@@ -56,9 +56,6 @@
 
 #define SQLITE_MANAGER "org.nemomobile.contacts.sqlite"
 
-//#define DEFAULT_MANAGER "memory"
-#define DEFAULT_MANAGER SQLITE_MANAGER
-
 //TESTED_COMPONENT=src/contacts
 //TESTED_CLASS=
 //TESTED_FILES=
@@ -263,7 +260,7 @@ void tst_QContactManager::initTestCase()
 {
     registerIdType();
 
-    managerDataHolder.reset(new QContactManagerDataHolder());
+    managerDataHolder.reset(new QContactManagerDataHolder(false));
 
     /* Make sure these other test plugins are NOT loaded by default */
     // These are now removed from the list of managers in addManagers()
@@ -487,6 +484,7 @@ void tst_QContactManager::uriParsing_data()
 QContactManager *tst_QContactManager::newContactManager(const QMap<QString, QString> &params)
 {
     QMap<QString, QString> parameters;
+    parameters.insert("autoTest", "true");
     parameters.insert("mergePresenceChanges", "false");
 
     QMap<QString, QString>::const_iterator it = params.constBegin(), end = params.constEnd();
@@ -494,7 +492,7 @@ QContactManager *tst_QContactManager::newContactManager(const QMap<QString, QStr
         parameters.insert(it.key(), it.value());
     }
 
-    return new QContactManager(DEFAULT_MANAGER, parameters);
+    return new QContactManager(SQLITE_MANAGER, parameters);
 }
 
 void tst_QContactManager::addManagers()
@@ -503,8 +501,9 @@ void tst_QContactManager::addManagers()
 
     // Only test the qtcontacts-sqlite engine
     QMap<QString, QString> params;
+    params.insert("autoTest", "true");
     params.insert("mergePresenceChanges", "false");
-    QTest::newRow("mgr='" DEFAULT_MANAGER "'") << QContactManager::buildUri(DEFAULT_MANAGER, params);
+    QTest::newRow("mgr='" SQLITE_MANAGER "'") << QContactManager::buildUri(SQLITE_MANAGER, params);
 }
 
 /*
@@ -1641,8 +1640,9 @@ void tst_QContactManager::presenceReporting_data()
     QTest::addColumn<bool>("mergePresenceChanges");
     QTest::addColumn<QString>("uri");
 
-    const QString managerName(QString::fromLatin1(DEFAULT_MANAGER));
+    const QString managerName(QString::fromLatin1(SQLITE_MANAGER));
     QMap<QString, QString> params;
+    params.insert("autoTest", "true");
 
     params.insert(QString::fromLatin1("mergePresenceChanges"), QString::fromLatin1("true"));
     QTest::newRow("mergePresenceChanges=true") << true << QContactManager::buildUri(managerName, params);
@@ -1756,8 +1756,9 @@ void tst_QContactManager::presenceAccumulation()
 
 void tst_QContactManager::nonprivileged()
 {
-    const QString managerName(QString::fromLatin1(DEFAULT_MANAGER));
+    const QString managerName(QString::fromLatin1(SQLITE_MANAGER));
     QMap<QString, QString> params;
+    params.insert("autoTest", "true");
 
     QScopedPointer<QContactManager> privilegedCm(QContactManager::fromUri(QContactManager::buildUri(managerName, params)));
     QVERIFY(privilegedCm);
@@ -2383,9 +2384,9 @@ void tst_QContactManager::signalEmission()
 #endif
     QVERIFY(m1->saveContact(&c2));
     modSigCount += 1;
-    if(uri.contains(QLatin1String("tracker")) || uri.contains(QLatin1String("sqlite"))) {
-        // tracker backend coalesces signals for performance reasons, so wait a little
-         QTest::qWait(1000);
+    if (uri.contains(QLatin1String("sqlite"))) {
+        // backend coalesces signals for performance reasons, so wait a little
+        QTest::qWait(1000);
     }
 #ifndef DETAIL_DEFINITION_SUPPORTED
     saveContactName(&c2, &nc2, "Mark");

--- a/tests/auto/qcontactmanagerfiltering/tst_qcontactmanagerfiltering.cpp
+++ b/tests/auto/qcontactmanagerfiltering/tst_qcontactmanagerfiltering.cpp
@@ -66,6 +66,14 @@ do {                                                                      \
  * This test is mostly just for testing sorting and filtering -
  * having it in tst_QContactManager makes maintenance more
  * difficult!
+ *
+ * Note: this test maintains the semantics of qtpim filtering, and
+ * thus works correctly only in nonprivileged mode (in privileged
+ * mode aggregation is used, which complicates filtering results).
+ * The test enforces access to the nonprivileged database.
+ *
+ * When changing the results of filtering, ensure that the privileged
+ * semantics are tested by the aggregation autotest.
  */
 
 Q_DECLARE_METATYPE(QVariant)
@@ -213,7 +221,7 @@ tst_QContactManagerFiltering::~tst_QContactManagerFiltering()
 
 void tst_QContactManagerFiltering::initTestCase()
 {
-    managerDataHolder.reset(new QContactManagerDataHolder());
+    managerDataHolder.reset(new QContactManagerDataHolder(true));
 
     // firstly, build a list of the managers we wish to test.
     QStringList managerNames;
@@ -221,6 +229,8 @@ void tst_QContactManagerFiltering::initTestCase()
 
     foreach (const QString &mgr, managerNames) {
         QMap<QString, QString> params;
+        params.insert(QStringLiteral("autoTest"), QStringLiteral("true"));
+        params.insert(QStringLiteral("nonprivileged"), QStringLiteral("true"));
         QString mgrUri = QContactManager::buildUri(mgr, params);
         QContactManager* cm = QContactManager::fromUri(mgrUri);
         cm->setObjectName(mgr);

--- a/tests/benchmarks/fetchtimes/main.cpp
+++ b/tests/benchmarks/fetchtimes/main.cpp
@@ -274,6 +274,7 @@ int main(int argc, char  *argv[])
     const bool quickMode(args.contains(QStringLiteral("-q")) || args.contains(QStringLiteral("--quick")));
 
     QMap<QString, QString> parameters;
+    parameters.insert(QString::fromLatin1("autoTest"), QString::fromLatin1("true"));
     parameters.insert(QString::fromLatin1("mergePresenceChanges"), QString::fromLatin1("false"));
 
     QContactManager manager(QString::fromLatin1("org.nemomobile.contacts.sqlite"), parameters);

--- a/tests/qcontactmanagerdataholder.h
+++ b/tests/qcontactmanagerdataholder.h
@@ -70,7 +70,7 @@ class QContact;
 class QContactManagerDataHolder
 {
 public:
-    QContactManagerDataHolder()
+    QContactManagerDataHolder(bool nonprivileged)
     {
         QStringList managerNames = QContactManager::availableManagers();
 
@@ -78,8 +78,14 @@ public:
             // Only test the qtcontacts-sqlite engine
             if (mgr != QLatin1String("org.nemomobile.contacts.sqlite"))
                 continue;
+
             QMap<QString, QString> params;
+            params.insert("autoTest", "true");
             params.insert("mergePresenceChanges", "false");
+            if (nonprivileged) {
+                params.insert("nonprivileged", "true");
+            }
+
             QString mgrUri = QContactManager::buildUri(mgr, params);
             QContactManager* cm = QContactManager::fromUri(mgrUri);
             if (cm) {

--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -5,12 +5,15 @@
        <set name="unit-tests" feature="qtcontacts-sqlite-qt5">
            <description>Backend correctness automatic tests</description>
            <case manual="false" name="aggregation">
+               <step>rm -rf /home/nemo/.local/share/system/privileged/Contacts/qtcontacts-sqlite-test</step>
                <step>/opt/tests/qtcontacts-sqlite-qt5/tst_aggregation</step>
            </case>
            <case manual="false" name="contactmanager">
+               <step>rm -rf /home/nemo/.local/share/system/privileged/Contacts/qtcontacts-sqlite-test</step>
                <step>/opt/tests/qtcontacts-sqlite-qt5/tst_qcontactmanager</step>
            </case>
            <case manual="false" name="contactmanagerfiltering">
+               <step>rm -rf /home/nemo/.local/share/system/Contacts/qtcontacts-sqlite-test</step>
                <step>/opt/tests/qtcontacts-sqlite-qt5/tst_qcontactmanagerfiltering</step>
            </case>
            <case manual="false" name="database">


### PR DESCRIPTION
The contacts engine creates a synchronous DB connection at startup,
and creates an asynchronous DB connection on demand.  Clients using
libcontacts, however, will exclusively use the asynchronous
connection, so the primary connection is entirely unnecessary.

Change the startup procedure so that the asynchronous connection
becomes the primary connection and the synchronous is created as
required.

Note: currently includes https://github.com/nemomobile/qtcontacts-sqlite/pull/184