### PR TITLE
[qtcontacts-sqlite] Ensure that sync resolution maintains modifiability flag

### DIFF
--- a/tests/auto/aggregation/testsyncadapter.cpp
+++ b/tests/auto/aggregation/testsyncadapter.cpp
@@ -32,6 +32,7 @@
 
 #include "testsyncadapter.h"
 #include "../../../src/extensions/twowaycontactsyncadapter_impl.h"
+#include "../../../src/extensions/qtcontacts-extensions.h"
 
 #include <QTimer>
 
@@ -62,7 +63,7 @@ TestSyncAdapter::~TestSyncAdapter()
 {
 }
 
-void TestSyncAdapter::addRemoteContact(const QString &accountId, const QString &fname, const QString &lname, const QString &phone)
+void TestSyncAdapter::addRemoteContact(const QString &accountId, const QString &fname, const QString &lname, const QString &phone, TestSyncAdapter::PhoneModifiability mod)
 {
     QContactName ncn;
     ncn.setFirstName(fname);
@@ -70,6 +71,11 @@ void TestSyncAdapter::addRemoteContact(const QString &accountId, const QString &
 
     QContactPhoneNumber ncp;
     ncp.setNumber(phone);
+    if (mod == TestSyncAdapter::ExplicitlyModifiable) {
+        ncp.setValue(QContactDetail__FieldModifiable, true);
+    } else if (mod == TestSyncAdapter::ExplicitlyNonModifiable) {
+        ncp.setValue(QContactDetail__FieldModifiable, false);
+    }
 
     QContact newContact;
     newContact.saveDetail(&ncn);

--- a/tests/auto/aggregation/testsyncadapter.h
+++ b/tests/auto/aggregation/testsyncadapter.h
@@ -52,8 +52,14 @@ public:
     TestSyncAdapter(QObject *parent = 0);
     ~TestSyncAdapter();
 
+    enum PhoneModifiability {
+        ImplicitlyModifiable = 0,
+        ExplicitlyModifiable,
+        ExplicitlyNonModifiable
+    };
+
     // for testing purposes
-    void addRemoteContact(const QString &accountId, const QString &fname, const QString &lname, const QString &phone);
+    void addRemoteContact(const QString &accountId, const QString &fname, const QString &lname, const QString &phone, PhoneModifiability mod = ImplicitlyModifiable);
     void removeRemoteContact(const QString &accountId, const QString &fname, const QString &lname);
     void setRemoteContact(const QString &accountId, const QString &fname, const QString &lname, const QContact &contact);
     void changeRemoteContactPhone(const QString &accountId, const QString &fname, const QString &lname, const QString &modPhone);


### PR DESCRIPTION
Previously, the sync resolution function could sometimes clobber the
value of the Modifiable flag on details which are modified.
This commit ensures that the value is explicitly set during every
sync resolution save operation, either to the value defined by the
sync adapter or to true if the sync adapter did not define the value.