### PR TITLE
[qtcontacts-sqlite] Improve resilience against invalid sync updates

### DIFF
--- a/src/extensions/twowaycontactsyncadapter_impl.h
+++ b/src/extensions/twowaycontactsyncadapter_impl.h
@@ -454,6 +454,7 @@ void dumpContactDetail(const QContactDetail &d)
 
 void dumpContact(const QContact &c)
 {
+    qWarning() << "++++ ---- Contact:" << c.id();
     QList<QContactDetail> cdets = c.details();
     removeIgnorableDetailsFromList(&cdets, defaultIgnorableDetailTypes());
     foreach (const QContactDetail &det, cdets) {
@@ -1380,7 +1381,13 @@ bool TwoWayContactSyncAdapter::purgeSyncStateData(const QString &accountId, bool
         purgeKeys << QStringLiteral("definitelyDownloadedAdditions");
     }
 
-    if (!d->m_engine->removeOOB(syncState.m_oobScope, purgeKeys)) {
+    // If this function is called without first calling initSyncAdapter, the
+    // OOB scope variable will not be initialized.  In that case, try to use
+    // the default OOB scope instead.
+    if (syncState.m_oobScope.isEmpty()) {
+        qWarning() << Q_FUNC_INFO << "error - cannot purge sync state data for uninitialized adapter";
+        purgeSucceeded = false;
+    } else if (!d->m_engine->removeOOB(syncState.m_oobScope, purgeKeys)) {
         qWarning() << Q_FUNC_INFO << "error - couldn't purge state data from oob!";
         purgeSucceeded = false;
     }

--- a/src/extensions/twowaycontactsyncadapter_impl.h
+++ b/src/extensions/twowaycontactsyncadapter_impl.h
@@ -795,15 +795,23 @@ QContact TwoWayContactSyncAdapterPrivate::applyRemoteDeltaToPrev(const QContact 
 
     for (int i = 0; i < additions.size(); ++i) {
         QContactDetail addition = additions.at(i);
-        newRemote.saveDetail(&addition);
-        QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("adding detail:");
+        if (addition.type() == QContactDetail::TypeUndefined) {
+            qWarning() << Q_FUNC_INFO << "invalid detail addition at index" << i << ": FIXME!";
+        } else {
+            newRemote.saveDetail(&addition);
+            QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("adding detail:");
+        }
         QTCONTACTS_SQLITE_TWCSA_DEBUG_DETAIL(addition);
     }
 
     for (int i = 0; i < modifications.size(); ++i) {
         QContactDetail modification = modifications.at(i);
-        newRemote.saveDetail(&modification);
-        QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("modifying detail:");
+        if (modification.type() == QContactDetail::TypeUndefined) {
+            qWarning() << Q_FUNC_INFO << "invalid detail modification at index" << i << ": FIXME!";
+        } else {
+            newRemote.saveDetail(&modification);
+            QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("modifying detail:");
+        }
         QTCONTACTS_SQLITE_TWCSA_DEBUG_DETAIL(modification);
     }
 
@@ -848,7 +856,7 @@ QList<QContactDetail> TwoWayContactSyncAdapterPrivate::improveDelta(QList<QConta
         }
     }
 
-        QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("ended up with: a/m/r:" << finalAdditions.size() << "/" << finalModifications.size() << "/" << finalRemovals.size());
+    QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("ended up with detail a/m/r:" << finalAdditions.size() << "/" << finalModifications.size() << "/" << finalRemovals.size());
 
     *removals = finalRemovals;
     *additions = finalAdditions;

--- a/tests/auto/aggregation/testsyncadapter.cpp
+++ b/tests/auto/aggregation/testsyncadapter.cpp
@@ -152,6 +152,28 @@ void TestSyncAdapter::changeRemoteContactEmail(const QString &accountId,  const 
     m_remoteAddMods[accountId].insert(contactGuidStr);
 }
 
+void TestSyncAdapter::changeRemoteContactName(const QString &accountId, const QString &fname, const QString &lname, const QString &modfname, const QString &modlname)
+{
+    const QString contactGuidStr(TSA_GUID_STRING(accountId, fname, lname));
+    if (!m_remoteServerContacts[accountId].contains(contactGuidStr)) {
+        qWarning() << "Contact:" << contactGuidStr << "doesn't exist remotely!";
+        return;
+    }
+
+    QContact modContact = m_remoteServerContacts[accountId][contactGuidStr];
+    QContactName mcn = modContact.detail<QContactName>();
+    if (modfname.isEmpty() && modlname.isEmpty()) {
+        modContact.removeDetail(&mcn);
+    } else {
+        mcn.setFirstName(modfname);
+        mcn.setLastName(modlname);
+        modContact.saveDetail(&mcn);
+    }
+
+    m_remoteServerContacts[accountId].insert(contactGuidStr, modContact);
+    m_remoteAddMods[accountId].insert(contactGuidStr);
+}
+
 void TestSyncAdapter::performTwoWaySync(const QString &accountId)
 {
     // reset our state.

--- a/tests/auto/aggregation/testsyncadapter.cpp
+++ b/tests/auto/aggregation/testsyncadapter.cpp
@@ -54,13 +54,23 @@ QMap<QString, QString> managerParameters() {
 
 }
 
-TestSyncAdapter::TestSyncAdapter(QObject *parent)
+TestSyncAdapter::TestSyncAdapter(const QString &accountId, QObject *parent)
     : QObject(parent), TwoWayContactSyncAdapter(QStringLiteral("testsyncadapter"), managerParameters())
+    , m_accountId(accountId)
 {
+    cleanUp(accountId);
 }
 
 TestSyncAdapter::~TestSyncAdapter()
 {
+    cleanUp(m_accountId);
+}
+
+void TestSyncAdapter::cleanUp(const QString &accountId)
+{
+    initSyncAdapter(accountId);
+    readSyncStateData(&m_remoteSince[accountId], accountId, TwoWayContactSyncAdapter::ReadPartialState);
+    purgeSyncStateData(accountId, true);
 }
 
 void TestSyncAdapter::addRemoteContact(const QString &accountId, const QString &fname, const QString &lname, const QString &phone, TestSyncAdapter::PhoneModifiability mod)
@@ -203,7 +213,7 @@ void TestSyncAdapter::determineRemoteChanges(const QDateTime &, const QString &a
     if (!m_simulationTimers.contains(accountId)) {
         simtimer = new QTimer(this);
         simtimer->setSingleShot(true);
-        simtimer->setInterval(1100);
+        simtimer->setInterval(200); // simulate network latency
         simtimer->setProperty("accountId", accountId);
         m_simulationTimers.insert(accountId, simtimer);
     } else {
@@ -310,7 +320,7 @@ void TestSyncAdapter::upsyncLocalChanges(const QDateTime &,
     if (!m_simulationTimers.contains(accountId)) {
         simtimer = new QTimer(this);
         simtimer->setSingleShot(true);
-        simtimer->setInterval(1100);
+        simtimer->setInterval(200); // simulate network latency.
         simtimer->setProperty("accountId", accountId);
         m_simulationTimers.insert(accountId, simtimer);
     } else {

--- a/tests/auto/aggregation/testsyncadapter.h
+++ b/tests/auto/aggregation/testsyncadapter.h
@@ -64,6 +64,7 @@ public:
     void setRemoteContact(const QString &accountId, const QString &fname, const QString &lname, const QContact &contact);
     void changeRemoteContactPhone(const QString &accountId, const QString &fname, const QString &lname, const QString &modPhone);
     void changeRemoteContactEmail(const QString &accountId, const QString &fname, const QString &lname, const QString &modEmail);
+    void changeRemoteContactName(const QString &accountId, const QString &fname, const QString &lname, const QString &modfname, const QString &modlname);
 
 
     // triggering sync and checking state.

--- a/tests/auto/aggregation/testsyncadapter.h
+++ b/tests/auto/aggregation/testsyncadapter.h
@@ -49,7 +49,7 @@ class TestSyncAdapter : public QObject, public QtContactsSqliteExtensions::TwoWa
     Q_OBJECT
 
 public:
-    TestSyncAdapter(QObject *parent = 0);
+    TestSyncAdapter(const QString &accountId, QObject *parent = 0);
     ~TestSyncAdapter();
 
     enum PhoneModifiability {
@@ -96,6 +96,8 @@ private Q_SLOTS:
     void finalizeTwoWaySync();
 
 private:
+    void cleanUp(const QString &accountId);
+    QString m_accountId;
     // simulating server-side changes, per account:
     mutable QMap<QString, QTimer*> m_simulationTimers;
     mutable QMap<QString, bool> m_downsyncWasRequired;

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -6403,7 +6403,7 @@ void tst_Aggregation::testSyncAdapter()
 
     // add some contacts remotely, and downsync them.  It should not result in an upsync.
     QString accountId(QStringLiteral("1"));
-    TestSyncAdapter tsa;
+    TestSyncAdapter tsa(accountId);
     tsa.addRemoteContact(accountId, "John", "TsaOne", "1111111", TestSyncAdapter::ImplicitlyModifiable);
     tsa.addRemoteContact(accountId, "Bob", "TsaTwo", "2222222", TestSyncAdapter::ExplicitlyModifiable);
     tsa.addRemoteContact(accountId, "Mark", "TsaThree", "3333333", TestSyncAdapter::ExplicitlyNonModifiable);
@@ -6744,6 +6744,7 @@ void tst_Aggregation::testSyncAdapter()
     QVERIFY(m_cm->removeContact(tsaFiveAgg.id()));
     QVERIFY(m_cm->removeContact(tsaSixAgg.id()));
     QCOMPARE(m_cm->contactIds(allSyncTargets).size(), originalIds.size());
+    tsa.removeAllContacts();
 }
 
 QTEST_MAIN(tst_Aggregation)

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -6659,6 +6659,91 @@ void tst_Aggregation::testSyncAdapter()
     foreach (const QContactId &id, allIds) {
         QVERIFY(originalIds.contains(id));
     }
+
+    // now add a new contact remotely, which has a name.
+    // remove the name locally, and modify it remotely - this will cause a "composed detail" modification update.
+    tsa.addRemoteContact(accountId, "John", "TsaFive", "555555", TestSyncAdapter::ImplicitlyModifiable);
+    tsa.performTwoWaySync(accountId);
+    QTRY_COMPARE(finishedSpy.count(), 11);
+    allIds = m_cm->contactIds(allSyncTargets);
+    QCOMPARE(allIds.size(), originalIds.size() + 2); // remote + aggregate
+    allContacts = m_cm->contacts(allSyncTargets);
+    QContact tsaFiveStc, tsaFiveAgg;
+    for (int i = allContacts.size() - 1; i >= 0; --i) {
+        const QContact &c(allContacts[i]);
+        if (originalIds.contains(c.id())) {
+            allContacts.removeAt(i);
+        } else {
+            bool isAggregate = c.relatedContacts(QStringLiteral("Aggregates"), QContactRelationship::Second).size() > 0;
+            if (isAggregate) {
+                tsaFiveAgg = c;
+            } else {
+                tsaFiveStc = c;
+            }
+        }
+    }
+    QVERIFY(tsaFiveAgg.id() != QContactId());
+    QVERIFY(tsaFiveStc.id() != QContactId());
+    // now remove the name on the local copy
+    QContactName tsaFiveName = tsaFiveStc.detail<QContactName>();
+    tsaFiveStc.removeDetail(&tsaFiveName);
+    QVERIFY(m_cm->saveContact(&tsaFiveStc));
+    // now modify the name on the remote server, and trigger sync.
+    // during this process, the local contact will NOT have a QContactName detail
+    // so the modification pair will be <null, newName>.  This used to trigger a bug.
+    tsa.changeRemoteContactName(accountId, "John", "TsaFive", "Jonathan", "TsaFive");
+    tsa.performTwoWaySync(accountId);
+    QTRY_COMPARE(finishedSpy.count(), 12);
+    // ensure that the contact contains the data we expect
+    // currently, we only support PreserveLocalChanges conflict resolution
+    tsaFiveStc = m_cm->contact(tsaFiveStc.id());
+    QCOMPARE(tsaFiveStc.detail<QContactName>().firstName(), QString());
+    QCOMPARE(tsaFiveStc.detail<QContactName>().lastName(), QString());
+    QCOMPARE(tsaFiveStc.detail<QContactPhoneNumber>().number(), QStringLiteral("555555"));
+    // now do the same test as above, but this time remove the name remotely and modify it locally.
+    tsa.addRemoteContact(accountId, "James", "TsaSix", "666666", TestSyncAdapter::ImplicitlyModifiable);
+    tsa.performTwoWaySync(accountId);
+    QTRY_COMPARE(finishedSpy.count(), 13);
+    allIds = m_cm->contactIds(allSyncTargets);
+    QCOMPARE(allIds.size(), originalIds.size() + 4); // remote + aggregate for Five and Six
+    allContacts = m_cm->contacts(allSyncTargets);
+    QContact tsaSixStc, tsaSixAgg;
+    for (int i = allContacts.size() - 1; i >= 0; --i) {
+        const QContact &c(allContacts[i]);
+        if (originalIds.contains(c.id())) {
+            allContacts.removeAt(i);
+        } else {
+            bool isAggregate = c.relatedContacts(QStringLiteral("Aggregates"), QContactRelationship::Second).size() > 0;
+            if (isAggregate && c.id() != tsaFiveAgg.id()) {
+                tsaSixAgg = c;
+            } else if (!isAggregate && c.id() != tsaFiveStc.id()){
+                tsaSixStc = c;
+            }
+        }
+    }
+    QVERIFY(tsaSixAgg.id() != QContactId());
+    QVERIFY(tsaSixStc.id() != QContactId());
+    // now modify the name on the local copy
+    QContactName tsaSixName = tsaSixStc.detail<QContactName>();
+    tsaSixName.setFirstName("Jimmy");
+    tsaSixStc.saveDetail(&tsaSixName);
+    QVERIFY(m_cm->saveContact(&tsaSixStc));
+    // now remove the name on the remote server, and trigger sync.
+    // during this process, the remote contact will NOT have a QContactName detail
+    // so the modification pair will be <newName, null>.
+    tsa.changeRemoteContactName(accountId, "James", "TsaSix", "", "");
+    tsa.performTwoWaySync(accountId);
+    QTRY_COMPARE(finishedSpy.count(), 14);
+    // ensure that the contact contains the data we expect
+    // currently, we only support PreserveLocalChanges conflict resolution
+    tsaSixStc = m_cm->contact(tsaSixStc.id());
+    QCOMPARE(tsaSixStc.detail<QContactName>().firstName(), QStringLiteral("Jimmy"));
+    QCOMPARE(tsaSixStc.detail<QContactName>().lastName(), QStringLiteral("TsaSix"));
+    QCOMPARE(tsaSixStc.detail<QContactPhoneNumber>().number(), QStringLiteral("666666"));
+    // clean up.
+    QVERIFY(m_cm->removeContact(tsaFiveAgg.id()));
+    QVERIFY(m_cm->removeContact(tsaSixAgg.id()));
+    QCOMPARE(m_cm->contactIds(allSyncTargets).size(), originalIds.size());
 }
 
 QTEST_MAIN(tst_Aggregation)


### PR DESCRIPTION
Add checks to avoid attempting to store invalid details during sync update.