### PR TITLE
Fix out-of-bounds access to local array

### DIFF
--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -90,7 +90,7 @@ namespace {
 
         int frequency[256] = { 0 };
         for ( ; it != end; ++it) {
-            frequency[static_cast<int>(*it)] += 1;
+            frequency[static_cast<unsigned char>(*it)] += 1;
         }
         for (int i = 0; i < 256; ++i) {
             if (frequency[i] != 0) {


### PR DESCRIPTION
`QByteArray::const_iterator` is defined as `(const char *)`. If char is signed then `*it` may produce a negative number and `frequency[*it]` may end up writing to the stack below the location of the `frequency` variable. It's more or less OK if it's the bottom-most stack variable but in the optimized build the enthropy function gets inlined and that damages local variables of the function it's invoked from, i.e. `ContactWriter::storeOOB`. This actually does happen on tablet and crashes contactsd in all kinds of weird ways.