### PR TITLE
[qtcontacts-sqlite] Don't use sticky bit for unit tests

### DIFF
--- a/qtcontacts-sqlite.pro
+++ b/qtcontacts-sqlite.pro
@@ -2,5 +2,6 @@ TEMPLATE = subdirs
 SUBDIRS = \
         src \
         tests
+OTHER_FILES += rpm/qtcontacts-sqlite-qt5.spec
 
 tests.depends = src

--- a/rpm/qtcontacts-sqlite-qt5.spec
+++ b/rpm/qtcontacts-sqlite-qt5.spec
@@ -59,8 +59,3 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}
 %qmake5_install
 
-%post tests
-for n in tst_aggregation tst_qcontactmanager ; do
-    pathname=/opt/tests/qtcontacts-sqlite-qt5/$n
-    chgrp privileged $pathname && chmod g+s $pathname
-done

--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -6,11 +6,11 @@
            <description>Backend correctness automatic tests</description>
            <case manual="false" name="aggregation">
                <step>/usr/sbin/run-blts-root /bin/su -g privileged -c 'rm -rf /home/nemo/.local/share/system/privileged/Contacts/qtcontacts-sqlite-test' nemo</step>
-               <step>/opt/tests/qtcontacts-sqlite-qt5/tst_aggregation</step>
+               <step>/usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/qtcontacts-sqlite-qt5/tst_aggregation' nemo</step>
            </case>
            <case manual="false" name="contactmanager">
                <step>/usr/sbin/run-blts-root /bin/su -g privileged -c 'rm -rf /home/nemo/.local/share/system/privileged/Contacts/qtcontacts-sqlite-test' nemo</step>
-               <step>/opt/tests/qtcontacts-sqlite-qt5/tst_qcontactmanager</step>
+               <step>/usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/qtcontacts-sqlite-qt5/tst_qcontactmanager' nemo</step>
            </case>
            <case manual="false" name="contactmanagerfiltering">
                <step>rm -rf /home/nemo/.local/share/system/Contacts/qtcontacts-sqlite-test</step>


### PR DESCRIPTION
This commit ensures that the unit tests are run in privileged mode
with blts-tools instead of installed with the sticky bit set.