### PR TITLE
[qtcontacts-sqlite-extensions] Allow ignorable fields to be specified in TWCSA. Contributes to MER#941

### DIFF
--- a/src/extensions/twowaycontactsyncadapter.h
+++ b/src/extensions/twowaycontactsyncadapter.h
@@ -67,14 +67,16 @@ public:
                                     QList<QContact> *addModRemote,
                                     const QString &accountId,
                                     bool needToApplyDelta = true,
-                                    const QSet<QContactDetail::DetailType> &ignorableDetailTypes = QSet<QContactDetail::DetailType>());
+                                    const QSet<QContactDetail::DetailType> &ignorableDetailTypes = QSet<QContactDetail::DetailType>(),
+                                    const QHash<QContactDetail::DetailType, QSet<int> > &ignorableDetailFields = QHash<QContactDetail::DetailType, QSet<int> >());
     // step five: determine which contact changes occurred locally.
     virtual bool determineLocalChanges(QDateTime *localSince,
                                        QList<QContact> *locallyAdded,
                                        QList<QContact> *locallyModified,
                                        QList<QContact> *locallyDeleted,
                                        const QString &accountId,
-                                       const QSet<QContactDetail::DetailType> &ignorableDetailTypes = QSet<QContactDetail::DetailType>());
+                                       const QSet<QContactDetail::DetailType> &ignorableDetailTypes = QSet<QContactDetail::DetailType>(),
+                                       const QHash<QContactDetail::DetailType, QSet<int> > &ignorableDetailFields = QHash<QContactDetail::DetailType, QSet<int> >());
     // step six: store those changes to the remote server
     //   this is asynchronous and implementation-specific.
     virtual void upsyncLocalChanges(const QDateTime &localSince,


### PR DESCRIPTION
Previously, the fields which were ignored during delta detection were
hardcoded (to just the provenance and modifiability flag).

This commit allows individual sync adapters to specify which fields
of which details should be ignored when performing sync, to accommodate
sync services which don't support all possible fields.

It also improves debug logging significantly so that individual detail
differences can be displayed when QTCONTACTS_SQLITE_TWCSA_TRACE=1 is
set in the environment at runtime.

Contributes to MER#941