### PR TITLE
[qtcontacts-sqlite] Improve remote removal sync update handling. Contributes to MER#953

### DIFF
--- a/src/engine/contactwriter.cpp
+++ b/src/engine/contactwriter.cpp
@@ -4648,19 +4648,19 @@ QContactManager::Error ContactWriter::syncUpdate(const QString &syncTarget,
             }
         }
 
+        // even if we previously affected some constituent, we should remove that
+        // constituent if it is contained in the contactsToRemove list.
         QSet<quint32> modifiedContactsToRemove;
         QSet<quint32>::const_iterator rit = contactsToRemove.constBegin(), rend = contactsToRemove.constEnd();
         for ( ; rit != rend; ++rit) {
-            if (!affectedContactIds.contains(*rit)) {
-                const quint32 stId(stConstituents.value(*rit));
-                if (stId != 0) {
-                    // Remove the sync target consituent instead of the base constituent
-                    modifiedContactsToRemove.insert(stId);
-                    affectedContactIds.insert(stId);
-                } else {
-                    modifiedContactsToRemove.insert(*rit);
-                    affectedContactIds.insert(*rit);
-                }
+            const quint32 stId(stConstituents.value(*rit));
+            if (stId != 0) {
+                // Remove the sync target consituent instead of the base constituent
+                modifiedContactsToRemove.insert(stId);
+                affectedContactIds.insert(stId);
+            } else {
+                modifiedContactsToRemove.insert(*rit);
+                affectedContactIds.insert(*rit);
             }
         }
         contactsToRemove = modifiedContactsToRemove;
@@ -4708,6 +4708,9 @@ QContactManager::Error ContactWriter::syncUpdate(const QString &syncTarget,
                     if (cst != syncTarget) {
                         if (cst == localSyncTarget || cst == wasLocalSyncTarget) {
                             // We have tried to remove a local contact that has no incidental sync target constituent - ignore
+                            // TODO, shouldn't we also check "exportedIds"?
+                            QTCONTACTS_SQLITE_DEBUG(QString::fromLatin1("Ignoring local contact removal without sync target constituent: %1")
+                                    .arg(contactId));
                         } else {
                             QTCONTACTS_SQLITE_WARNING(QString::fromLatin1("Ignoring constituent removal for %1 with invalid sync target: %2")
                                     .arg(contactId).arg(cst));

--- a/tests/auto/aggregation/testsyncadapter.h
+++ b/tests/auto/aggregation/testsyncadapter.h
@@ -65,7 +65,8 @@ public:
     void changeRemoteContactPhone(const QString &accountId, const QString &fname, const QString &lname, const QString &modPhone);
     void changeRemoteContactEmail(const QString &accountId, const QString &fname, const QString &lname, const QString &modEmail);
     void changeRemoteContactName(const QString &accountId, const QString &fname, const QString &lname, const QString &modfname, const QString &modlname);
-
+    void addRemoteDuplicates(const QString &accountId, const QString &fname, const QString &lname, const QString &phone);
+    void mergeRemoteDuplicates(const QString &accountId);
 
     // triggering sync and checking state.
     void performTwoWaySync(const QString &accountId);
@@ -107,6 +108,7 @@ private:
     mutable QMap<QString, QSet<QString> > m_remoteAddMods; // used to lookup into m_remoteServerContacts
     mutable QMap<QString, QMap<QString, QContact> > m_remoteServerContacts;
     mutable QMap<QString, QSet<QContactId> > m_modifiedIds;
+    mutable QMap<QString, QMultiMap<QString, QString> > m_remoteServerDuplicates; // accountId to originalGuid to duplicateGuids.
 };
 
 #endif


### PR DESCRIPTION
When multiple contacts are merged server-side (due to duplicate
detection), multiple constituents of the same aggregate may need
to be removed within the same sync operation.

This commit ensures that we deal with all server-side removal
entries in the update list, even if previous updates may have
caused modification to the (shared) aggregate of those
server-side removals.

Contributes to MER#953