### PR TITLE
[qtcontacts-sqlite] Improve handling of multiple sync target constituents. Contributes to MER#1053

### DIFF
--- a/src/extensions/twowaycontactsyncadapter_impl.h
+++ b/src/extensions/twowaycontactsyncadapter_impl.h
@@ -725,7 +725,7 @@ QList<QPair<QContact, QContact> > TwoWayContactSyncAdapterPrivate::createUpdateL
                 QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("contact:" << pcGuid << "was never seen locally but reported as deleted remotely...");
             }
         } else {
-            QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("contact:" << prevContact.detail<QContactGuid>().guid() << "marked as deleted remotely, found at index" << prevIndex);
+            QTCONTACTS_SQLITE_TWCSA_DEBUG_LOG("contact:" << prevContact.detail<QContactGuid>().guid() << "with id" << id << "marked as deleted remotely, found at index" << prevIndex);
             deletePositions.append(prevIndex);
             syncState.m_remotelyDeletedThisSync.append(id);
         }

--- a/tests/auto/aggregation/tst_aggregation.cpp
+++ b/tests/auto/aggregation/tst_aggregation.cpp
@@ -6592,7 +6592,7 @@ void tst_Aggregation::testSyncAdapter()
     QVERIFY(tsaFourAggId != QContactId());
     tsa.performTwoWaySync(accountId);
     QTRY_COMPARE(finishedSpy.count(), 7);
-    QVERIFY(tsa.downsyncWasRequired(accountId));
+    QVERIFY(!tsa.downsyncWasRequired(accountId)); // there were no remote changes
     QVERIFY(tsa.upsyncWasRequired(accountId));
     QVERIFY(haveExpectedContent(tsa.remoteContact(accountId, QStringLiteral("Jennifer"), QStringLiteral("TsaFour")),
                                 QString(), TestSyncAdapter::ImplicitlyModifiable, QStringLiteral("jennifer@tsafour.com")));


### PR DESCRIPTION
Previously, the syncUpdate() function built a mapping from the
modified constituent to the appropriate sync target constituent,
in order to affect the appropriate sync target constituent instead
of the modified constituent.

The function previously did not consider the possibility that
multiple sync target constituents might be aggregated by a single
aggregate contact, and thus the mapping was incomplete.

This commit improves the mapping so that a modification to a
sync target constituent will not be re-directed to modify a
different sync target constituent (in the case where multiple
STCs exist for that contact).

It also improves the unit test to ensure that the state of the
server-side contact cache managed by the test sync adapter is
always consistent.

Contributes to MER#1053