### PR TITLE
[qtcontacts-sqlite] Allow enum property extensions to be stored. Contributes to MER#1368

### DIFF
--- a/tests/auto/database/database.pro
+++ b/tests/auto/database/database.pro
@@ -25,6 +25,9 @@ SOURCES += ../../../src/engine/contactstransientstore.cpp
 HEADERS += ../../../src/engine/memorytable.h
 SOURCES += ../../../src/engine/memorytable.cpp
 
+HEADERS += ../../../src/engine/conversion_p.h
+SOURCES += ../../../src/engine/conversion.cpp
+
 SOURCES += stub_contactsengine.cpp
 
 SOURCES += tst_database.cpp

--- a/tests/auto/memorytable/memorytable.pro
+++ b/tests/auto/memorytable/memorytable.pro
@@ -8,4 +8,5 @@ HEADERS += \
     ../../util.h
 SOURCES += \
     tst_memorytable.cpp \
+    ../../../src/engine/conversion.cpp \
     ../../../src/engine/memorytable.cpp


### PR DESCRIPTION
Due to the schema originating to support the QtMobility.Contacts API
we store some properties in string form, when the qtpim API now uses
user-extensible enum values. Passing all values through a translation
step that only knows the predefined values causes extension values to
be lost.

To fix this problem, perform a schema upgrade in which all pre-existing
text values are converted to the equivalent enum value. In some cases
the column containing these values should be typed as INTEGER, when
in fact it is typed as TEXT. To avoid changing the columns, the read
and write routines for these columns manually translate between text
and integral form.
